### PR TITLE
[Doran] step2 - UIStackView 분리 커밋 추가

### DIFF
--- a/PokergameApp/PokergameApp.xcodeproj/project.pbxproj
+++ b/PokergameApp/PokergameApp.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C507FE6C2313CA4B002AC86D /* SizeInfoStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507FE6A2313CA4A002AC86D /* SizeInfoStructs.swift */; };
+		C507FE6D2313CA4B002AC86D /* UICardStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C507FE6B2313CA4B002AC86D /* UICardStackView.swift */; };
 		C52FBE4623116DD800E9D4F9 /* DrawCardError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52FBE4523116DD800E9D4F9 /* DrawCardError.swift */; };
 		C548618F230415A400F6555C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C548618E230415A400F6555C /* AppDelegate.swift */; };
 		C5486191230415A400F6555C /* CardGameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5486190230415A400F6555C /* CardGameViewController.swift */; };
@@ -34,6 +36,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		C507FE6A2313CA4A002AC86D /* SizeInfoStructs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SizeInfoStructs.swift; sourceTree = "<group>"; };
+		C507FE6B2313CA4B002AC86D /* UICardStackView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICardStackView.swift; sourceTree = "<group>"; };
 		C52FBE4523116DD800E9D4F9 /* DrawCardError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawCardError.swift; sourceTree = "<group>"; };
 		C548618B230415A400F6555C /* PokergameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokergameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C548618E230415A400F6555C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +100,8 @@
 				C548618E230415A400F6555C /* AppDelegate.swift */,
 				C5486190230415A400F6555C /* CardGameViewController.swift */,
 				C59ABA84230EA9D300FB2DBE /* DataController.swift */,
+				C507FE6B2313CA4B002AC86D /* UICardStackView.swift */,
+				C507FE6A2313CA4A002AC86D /* SizeInfoStructs.swift */,
 				C5C279DA230A720B009C7FE6 /* ImageInfo.swift */,
 				C5486192230415A400F6555C /* Main.storyboard */,
 				C5486195230415A600F6555C /* Assets.xcassets */,
@@ -282,6 +288,7 @@
 				C59ABA85230EA9D300FB2DBE /* DataController.swift in Sources */,
 				C5C279DB230A720B009C7FE6 /* ImageInfo.swift in Sources */,
 				C59ABA76230EA54000FB2DBE /* Player.swift in Sources */,
+				C507FE6D2313CA4B002AC86D /* UICardStackView.swift in Sources */,
 				C59ABA80230EA54000FB2DBE /* GameMenuError.swift in Sources */,
 				C59ABA79230EA54000FB2DBE /* GameType.swift in Sources */,
 				C59ABA7D230EA54000FB2DBE /* CardType.swift in Sources */,
@@ -295,6 +302,7 @@
 				C59ABA7E230EA54000FB2DBE /* CardNumber.swift in Sources */,
 				C59ABA81230EA54000FB2DBE /* GameResult.swift in Sources */,
 				C59ABA72230EA54000FB2DBE /* Card.swift in Sources */,
+				C507FE6C2313CA4B002AC86D /* SizeInfoStructs.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PokergameApp/PokergameApp/CardGameViewController.swift
+++ b/PokergameApp/PokergameApp/CardGameViewController.swift
@@ -29,20 +29,6 @@ class CardGameViewController: UIViewController {
             / CGFloat(cardGameSizeInfo.cardSize)) * cardGameSizeInfo.ratio
     }
     
-    private struct CardGameSizeInfo {
-        var cardSize = 7
-        var playerSize = 4
-        let ratio: CGFloat = 1.27
-        let bufferSize: CGFloat = 10
-    }
-    private struct StackViewSizeInfo {
-        let widthProportion: CGFloat = 0.1
-        let marginSpace: CGFloat = 0
-        var width: CGFloat = 0
-        var leftAlign: CGFloat = -20
-        var rightAlign: CGFloat = 20
-        var spacingSize: CGFloat = -10
-    }
     private struct SegmentControlsSizeInfo {
         let xCoordinate: CGFloat = 126
         let yCoordinateFirst: CGFloat = 100
@@ -316,12 +302,14 @@ class CardGameViewController: UIViewController {
         let numberOfPlayer = cardGameSizeInfo.playerSize
         for _ in 0..<numberOfPlayer {
             let rect = CGRect(x: 0, y: 0, width: stackViewSizeInfo.width, height: height)
-            let stackview = UIStackView.init(frame: rect)
+            let stackview = UICardStackView.init(frame: rect,
+                                                 number: cardGameSizeInfo.cardSize,
+                                                 stackViewSizeInfo: stackViewSizeInfo,
+                                                 height: height)
             stackviewList.append(stackview)
             let basicLabel = createBasicUILabel(rect)
             uiLabelList.append(basicLabel)
         }
-        setImageViewsInStackViewList(stackviewList)
         addStackViewList(stackviewList)
         addUILabelList(uiLabelList)
         setConstraintOfStackViewList(stackviewList)
@@ -393,27 +381,7 @@ class CardGameViewController: UIViewController {
                                                     multiplier: 1, constant: stackViewSizeInfo.spacingSize)
         return [leadingConstraint, topConstraint]
     }
-    
-    private func setImageViewsInStackViewList(_ list: [UIStackView]) {
-        for index in 0..<list.endIndex {
-            addImageViewsInStackView(list[index], order: index)
-        }
-    }
-    
-    private func addImageViewsInStackView(_ stackview: UIStackView, order: Int) {
-        let imageWidth = (initialRectSize.basicCGRect.width - stackViewSizeInfo.marginSpace
-            * CGFloat(cardGameSizeInfo.cardSize))/CGFloat(cardGameSizeInfo.cardSize)
-        let imageHeight = height
-        for _ in 0..<cardGameSizeInfo.cardSize {
-            let currentCardRect = CGRect.init(x: 0, y: 0, width: imageWidth, height: imageHeight)
-            let uiImageView = UIImageView.init(frame: currentCardRect)
-            uiImageView.image = UIImage.init(named: ImageInfo.cardBack)
-            stackview.addArrangedSubview(uiImageView)
-        }
-        stackview.distribution = .fillEqually
-        stackview.spacing = stackViewSizeInfo.marginSpace
-    }
-    
+
     private func setConstraintOfStackViewList(_ list: [UIStackView]) {
         var constraintList = [NSLayoutConstraint]()
         for index in 0..<list.endIndex {

--- a/PokergameApp/PokergameApp/CardGameViewController.swift
+++ b/PokergameApp/PokergameApp/CardGameViewController.swift
@@ -302,10 +302,8 @@ class CardGameViewController: UIViewController {
         let numberOfPlayer = cardGameSizeInfo.playerSize
         for _ in 0..<numberOfPlayer {
             let rect = CGRect(x: 0, y: 0, width: stackViewSizeInfo.width, height: height)
-            let stackview = UICardStackView.init(frame: rect,
-                                                 number: cardGameSizeInfo.cardSize,
-                                                 stackViewSizeInfo: stackViewSizeInfo,
-                                                 height: height)
+            let stackview = UICardStackView.init(frame: rect)
+            stackview.configure(stackViewSizeInfo: stackViewSizeInfo, cardSize: cardGameSizeInfo.cardSize)
             stackviewList.append(stackview)
             let basicLabel = createBasicUILabel(rect)
             uiLabelList.append(basicLabel)

--- a/PokergameApp/PokergameApp/SizeInfoStructs.swift
+++ b/PokergameApp/PokergameApp/SizeInfoStructs.swift
@@ -1,0 +1,25 @@
+//
+//  SizeInfoStructs.swift
+//  PokergameApp
+//
+//  Created by hw on 26/08/2019.
+//  Copyright © 2019 hwj. All rights reserved.
+//
+
+import UIKit
+
+struct CardGameSizeInfo {
+    var cardSize = 7
+    var playerSize = 4
+    let ratio: CGFloat = 1.27
+    let bufferSize: CGFloat = 10
+}
+
+struct StackViewSizeInfo {
+    let widthProportion: CGFloat = 0.1
+    let marginSpace: CGFloat = 0
+    var width: CGFloat = 0
+    var leftAlign: CGFloat = -20
+    var rightAlign: CGFloat = 20
+    var spacingSize: CGFloat = -10
+}

--- a/PokergameApp/PokergameApp/UICardStackView.swift
+++ b/PokergameApp/PokergameApp/UICardStackView.swift
@@ -11,27 +11,36 @@ import UIKit
 class UICardStackView: UIStackView {
     private var stackViewSizeInfo: StackViewSizeInfo = StackViewSizeInfo()
     private var initialRectSize = CGRect.init(x: 1, y: 1, width: 100, height: 30)
-    private var height: CGFloat
-    
-    init(frame: CGRect, number: Int, stackViewSizeInfo: StackViewSizeInfo, height: CGFloat) {
+    private var cardSize: Int = GameType.sevenCard.rawValue
+    override init(frame: CGRect) {
+        initialRectSize = frame
+        super.init(frame: frame)
+    }
+    //constructor injection
+    init(frame: CGRect, stackViewSizeInfo: StackViewSizeInfo, cardSize: Int){
         initialRectSize = frame
         self.stackViewSizeInfo = stackViewSizeInfo
-        self.height = height
-        
+        self.cardSize = cardSize
         super.init(frame: frame)
-        addImageViewsInStackView(number)
+        addImageViewsInStackView()
+    }
+    //setter injection
+    func configure(stackViewSizeInfo: StackViewSizeInfo, cardSize: Int){
+        self.stackViewSizeInfo = stackViewSizeInfo
+        self.cardSize = cardSize
+        addImageViewsInStackView()
     }
     
     required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
+        cardSize = coder.decodeObject(forKey: "cardSize") as! Int
     }
     
-    private func addImageViewsInStackView(_ cardSize: Int) {
+    private func addImageViewsInStackView() {
         let imageWidth = (initialRectSize.width - stackViewSizeInfo.marginSpace
             * CGFloat(cardSize))/CGFloat(cardSize)
-        let imageHeight = height
         for _ in 0..<cardSize {
-            let currentCardRect = CGRect.init(x: 0, y: 0, width: imageWidth, height: imageHeight)
+            let currentCardRect = CGRect.init(x: 0, y: 0, width: imageWidth, height: frame.height)
             let uiImageView = UIImageView.init(frame: currentCardRect)
             uiImageView.image = UIImage.init(named: ImageInfo.cardBack)
             self.addArrangedSubview(uiImageView)

--- a/PokergameApp/PokergameApp/UICardStackView.swift
+++ b/PokergameApp/PokergameApp/UICardStackView.swift
@@ -1,0 +1,42 @@
+//
+//  UICardStackView.swift
+//  PokergameApp
+//
+//  Created by hw on 26/08/2019.
+//  Copyright © 2019 hwj. All rights reserved.
+//
+
+import UIKit
+
+class UICardStackView: UIStackView {
+    private var stackViewSizeInfo: StackViewSizeInfo = StackViewSizeInfo()
+    private var initialRectSize = CGRect.init(x: 1, y: 1, width: 100, height: 30)
+    private var height: CGFloat
+    
+    init(frame: CGRect, number: Int, stackViewSizeInfo: StackViewSizeInfo, height: CGFloat) {
+        initialRectSize = frame
+        self.stackViewSizeInfo = stackViewSizeInfo
+        self.height = height
+        
+        super.init(frame: frame)
+        addImageViewsInStackView(number)
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func addImageViewsInStackView(_ cardSize: Int) {
+        let imageWidth = (initialRectSize.width - stackViewSizeInfo.marginSpace
+            * CGFloat(cardSize))/CGFloat(cardSize)
+        let imageHeight = height
+        for _ in 0..<cardSize {
+            let currentCardRect = CGRect.init(x: 0, y: 0, width: imageWidth, height: imageHeight)
+            let uiImageView = UIImageView.init(frame: currentCardRect)
+            uiImageView.image = UIImage.init(named: ImageInfo.cardBack)
+            self.addArrangedSubview(uiImageView)
+        }
+        self.distribution = .fillEqually
+        self.spacing = stackViewSizeInfo.marginSpace
+    }
+}

--- a/PokergameApp/PokergameApp/UICardStackView.swift
+++ b/PokergameApp/PokergameApp/UICardStackView.swift
@@ -32,8 +32,10 @@ class UICardStackView: UIStackView {
     }
     
     required init(coder: NSCoder) {
-        super.init(coder: coder)
         cardSize = coder.decodeObject(forKey: "cardSize") as! Int
+        stackViewSizeInfo = coder.decodeObject(forKey: "stackViewSizeInfo") as! StackViewSizeInfo
+        initialRectSize = coder.decodeObject(forKey: "initialRectSize") as! CGRect
+        super.init(coder: coder)
     }
     
     private func addImageViewsInStackView() {


### PR DESCRIPTION
추가 PR 요청드립니다.
- SizeInfo와 관련된 구조체들은 외부 파일로 분리했습니다.
- 카드 뒷면 이미지를 스택에 삽입한 채로 스택뷰 초기화 하도록 변경하였습니다.
- Constraints 등과 같은 것은 상위 뷰(superview)에 대한 접근이 필요할 수도 있기 때문에 ViewController에 두는게 낫다고 판단하였습니다. 
- 공통으로 쓰는 프로퍼티 값 (height) 등은 커스텀 스택뷰 생성시에 뷰컨트롤러의 값을 주입받도록 하였습니다.
