### PR TITLE
card deck 구현 및 단위 테스트 작성

### DIFF
--- a/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
+++ b/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		30476F0323EA7AE60046DAE5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 30476F0223EA7AE60046DAE5 /* Assets.xcassets */; };
 		30476F0623EA7AE60046DAE5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 30476F0423EA7AE60046DAE5 /* LaunchScreen.storyboard */; };
 		30BF90A023EBCA1000A5D728 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF909F23EBCA1000A5D728 /* Card.swift */; };
+		30BF90A223EC42FF00A5D728 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF90A123EC42FF00A5D728 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		30476F0523EA7AE60046DAE5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		30476F0723EA7AE60046DAE5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		30BF909F23EBCA1000A5D728 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		30BF90A123EC42FF00A5D728 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,6 +68,7 @@
 				30476F0423EA7AE60046DAE5 /* LaunchScreen.storyboard */,
 				30476F0723EA7AE60046DAE5 /* Info.plist */,
 				30BF909F23EBCA1000A5D728 /* Card.swift */,
+				30BF90A123EC42FF00A5D728 /* CardDeck.swift */,
 			);
 			path = CardGameApp;
 			sourceTree = "<group>";
@@ -142,6 +145,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				30476EFE23EA7AE30046DAE5 /* ViewController.swift in Sources */,
+				30BF90A223EC42FF00A5D728 /* CardDeck.swift in Sources */,
 				30476EFA23EA7AE30046DAE5 /* AppDelegate.swift in Sources */,
 				30476EFC23EA7AE30046DAE5 /* SceneDelegate.swift in Sources */,
 				30BF90A023EBCA1000A5D728 /* Card.swift in Sources */,

--- a/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
+++ b/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
@@ -15,7 +15,18 @@
 		30476F0623EA7AE60046DAE5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 30476F0423EA7AE60046DAE5 /* LaunchScreen.storyboard */; };
 		30BF90A023EBCA1000A5D728 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF909F23EBCA1000A5D728 /* Card.swift */; };
 		30BF90A223EC42FF00A5D728 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF90A123EC42FF00A5D728 /* CardDeck.swift */; };
+		30C0728A23ED796300DCE7AA /* CardGameAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C0728923ED796300DCE7AA /* CardGameAppTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		30C0728C23ED796300DCE7AA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 30476EEE23EA7AE30046DAE5 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 30476EF523EA7AE30046DAE5;
+			remoteInfo = CardGameApp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		30476EF623EA7AE30046DAE5 /* CardGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CardGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -28,10 +39,20 @@
 		30476F0723EA7AE60046DAE5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		30BF909F23EBCA1000A5D728 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		30BF90A123EC42FF00A5D728 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
+		30C0728723ED796300DCE7AA /* CardGameAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CardGameAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		30C0728923ED796300DCE7AA /* CardGameAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardGameAppTests.swift; sourceTree = "<group>"; };
+		30C0728B23ED796300DCE7AA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		30476EF323EA7AE30046DAE5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		30C0728423ED796300DCE7AA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -45,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				30476EF823EA7AE30046DAE5 /* CardGameApp */,
+				30C0728823ED796300DCE7AA /* CardGameAppTests */,
 				30476EF723EA7AE30046DAE5 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -53,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				30476EF623EA7AE30046DAE5 /* CardGameApp.app */,
+				30C0728723ED796300DCE7AA /* CardGameAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -71,6 +94,15 @@
 				30BF90A123EC42FF00A5D728 /* CardDeck.swift */,
 			);
 			path = CardGameApp;
+			sourceTree = "<group>";
+		};
+		30C0728823ED796300DCE7AA /* CardGameAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				30C0728923ED796300DCE7AA /* CardGameAppTests.swift */,
+				30C0728B23ED796300DCE7AA /* Info.plist */,
+			);
+			path = CardGameAppTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -93,6 +125,24 @@
 			productReference = 30476EF623EA7AE30046DAE5 /* CardGameApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		30C0728623ED796300DCE7AA /* CardGameAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 30C0729023ED796300DCE7AA /* Build configuration list for PBXNativeTarget "CardGameAppTests" */;
+			buildPhases = (
+				30C0728323ED796300DCE7AA /* Sources */,
+				30C0728423ED796300DCE7AA /* Frameworks */,
+				30C0728523ED796300DCE7AA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				30C0728D23ED796300DCE7AA /* PBXTargetDependency */,
+			);
+			name = CardGameAppTests;
+			productName = CardGameAppTests;
+			productReference = 30C0728723ED796300DCE7AA /* CardGameAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -105,6 +155,10 @@
 				TargetAttributes = {
 					30476EF523EA7AE30046DAE5 = {
 						CreatedOnToolsVersion = 11.3;
+					};
+					30C0728623ED796300DCE7AA = {
+						CreatedOnToolsVersion = 11.3;
+						TestTargetID = 30476EF523EA7AE30046DAE5;
 					};
 				};
 			};
@@ -122,6 +176,7 @@
 			projectRoot = "";
 			targets = (
 				30476EF523EA7AE30046DAE5 /* CardGameApp */,
+				30C0728623ED796300DCE7AA /* CardGameAppTests */,
 			);
 		};
 /* End PBXProject section */
@@ -134,6 +189,13 @@
 				30476F0623EA7AE60046DAE5 /* LaunchScreen.storyboard in Resources */,
 				30476F0323EA7AE60046DAE5 /* Assets.xcassets in Resources */,
 				30476F0123EA7AE30046DAE5 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		30C0728523ED796300DCE7AA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,7 +214,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		30C0728323ED796300DCE7AA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				30C0728A23ED796300DCE7AA /* CardGameAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		30C0728D23ED796300DCE7AA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 30476EF523EA7AE30046DAE5 /* CardGameApp */;
+			targetProxy = 30C0728C23ED796300DCE7AA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		30476EFF23EA7AE30046DAE5 /* Main.storyboard */ = {
@@ -324,6 +402,46 @@
 			};
 			name = Release;
 		};
+		30C0728E23ED796300DCE7AA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = NC28R53QWB;
+				INFOPLIST_FILE = CardGameAppTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.delma.CardGameAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CardGameApp.app/CardGameApp";
+			};
+			name = Debug;
+		};
+		30C0728F23ED796300DCE7AA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = NC28R53QWB;
+				INFOPLIST_FILE = CardGameAppTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.delma.CardGameAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CardGameApp.app/CardGameApp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -341,6 +459,15 @@
 			buildConfigurations = (
 				30476F0B23EA7AE60046DAE5 /* Debug */,
 				30476F0C23EA7AE60046DAE5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		30C0729023ED796300DCE7AA /* Build configuration list for PBXNativeTarget "CardGameAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				30C0728E23ED796300DCE7AA /* Debug */,
+				30C0728F23ED796300DCE7AA /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -25,22 +25,25 @@ class Card {
     
     enum Number: Int {
         case one = 1, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen
-        
-        func transformUniqueNumber(number: Number) -> String {
-            switch number {
-            case .one:
-                return "A"
-            case .eleven:
-                return "J"
-            case .twelve:
-                return "Q"
-            case .thirteen:
-                return "K"
-            default:
-                return "\(number)"
-            }
-        }
     }
     
 }
 
+extension Card: CustomStringConvertible {
+    var description: String {
+        var numberCharacter = ""
+        switch self.number {
+        case .one:
+            numberCharacter = "A"
+        case .eleven:
+            numberCharacter = "J"
+        case .twelve:
+            numberCharacter = "Q"
+        case .thirteen:
+            numberCharacter = "K"
+        default:
+            numberCharacter = "\(self.number)"
+        }
+        return "\(pattern.rawValue) \(numberCharacter)"
+    }
+}

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -16,14 +16,14 @@ class Card {
         self.pattern = pattern
     }
     
-    enum Pattern: Character {
+    enum Pattern: Character, CaseIterable {
         case spade = "♠️"
         case clover = "♣️"
         case heart = "♥️"
         case diamond = "♦️"
     }
     
-    enum Number: Int {
+    enum Number: Int, CaseIterable {
         case one = 1, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen
     }
     

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -47,3 +47,11 @@ extension Card: CustomStringConvertible {
         return "\(pattern.rawValue) \(numberCharacter)"
     }
 }
+
+extension Card: Equatable {
+    static func == (lhs: Card, rhs: Card) -> Bool {
+        return lhs.number == rhs.number && lhs.pattern == rhs.pattern
+    }
+    
+    
+}

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -8,5 +8,30 @@
 
 import Foundation
 struct CardDeck {
+    var cards :[Card] = []
+    
+    init() {
+        Card.Number.allCases.map { number in
+            Card.Pattern.allCases.map{ pattern in
+                cards.append(Card(number: number, pattern: pattern ))
+            }
+        }
+    }
+    
+    func count() -> Int {
+        return cards.count
+    }
+    
+    mutating func shuffle() {
+        self.cards = cards.shuffled()
+    }
+    
+    mutating func removeOn() -> Card {
+        return cards.removeFirst()
+    }
+    
+    func reset() {
+        type(of: self).init()
+    }
     
 }

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -1,0 +1,12 @@
+//
+//  CardDeck.swift
+//  CardGameApp
+//
+//  Created by delma on 06/02/2020.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import Foundation
+struct CardDeck {
+    
+}

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -23,15 +23,15 @@ struct CardDeck {
     }
     
     mutating func shuffle() {
-        self.cards = cards.shuffled()
+        cards.shuffle()
     }
     
-    mutating func removeOn() -> Card {
+    mutating func removeOne() -> Card? {
         return cards.removeFirst()
     }
     
-    func reset() {
-        type(of: self).init()
+    mutating func reset() {
+        self = .init()
     }
     
 }

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 struct CardDeck {
-    var cards :[Card] = []
+    private var cards :[Card] = []
     
     init() {
         Card.Number.allCases.map { number in

--- a/CardGameApp/CardGameApp/ViewController.swift
+++ b/CardGameApp/CardGameApp/ViewController.swift
@@ -13,9 +13,6 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
-
-        let card = Card(number: .one, pattern: .clover)
-        print(card.description)
     }
     
     let cardImageStack: UIStackView = {

--- a/CardGameApp/CardGameApp/ViewController.swift
+++ b/CardGameApp/CardGameApp/ViewController.swift
@@ -15,8 +15,7 @@ class ViewController: UIViewController {
         setUI()
 
         let card = Card(number: .one, pattern: .clover)
-        print(card.number.transformUniqueNumber(number: card.number))
-        print(card.pattern.rawValue)
+        print(card.description)
     }
     
     let cardImageStack: UIStackView = {

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -11,50 +11,41 @@ import XCTest
 
 class CardGameAppTests: XCTestCase {
 
+    var cardDeck: CardDeck!
+    
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
         super.setUp()
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() {
-        
-       
-        
-        
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
-    func testCardShuffle() {
-        let cardDeck = CardDeck()
-        let output = """
-            > 카드 섞기
-            전체 \(cardDeck.count())장의 카드를 섞었습니다.
-            """
-        print(output)
-    }
-    func testInitCard() {
-         let cardDeck = CardDeck()
-        print("> 카드 초기화\n카드 전체를 초기화했습니다.\n총 \(cardDeck.count())장의 카드를 섞었습니다.")
+        cardDeck = CardDeck()
     }
     
-    func testPickOneCard() {
-        var cardDeck = CardDeck()
-        let output = """
-        > 카드 하나 뽑기
-        \(cardDeck.removeOn())
-        총 \(cardDeck.count())장의 카드가 남아있습니다.
-        """
-        print(output)
+    func testCount() {
+         XCTAssertEqual(cardDeck.count(), 52)
+    }
+    
+    func testShuffle() {
+        let beforeShuffle = (0..<52).map { _ in  cardDeck.removeOne()
+        }
+        cardDeck.shuffle()
+        let afterShuffle = (0..<52).map { _ in
+            cardDeck.removeOne()
+        }
+        XCTAssertNotEqual(beforeShuffle, afterShuffle)
+        
+    }
+    
+    func testRemoveOne() {
+        cardDeck.removeOne()
+        XCTAssertEqual(cardDeck.count(), 51)
+        cardDeck.removeOne()
+        XCTAssertEqual(cardDeck.count(), 50)
+    }
+    
+    func testReset() {
+        XCTAssertEqual(cardDeck.count(), 52)
+        cardDeck.removeOne()
+        cardDeck.removeOne()
+        cardDeck.reset()
+        XCTAssertEqual(cardDeck.count(), 52)
     }
     
 }

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -1,0 +1,60 @@
+//
+//  CardGameAppTests.swift
+//  CardGameAppTests
+//
+//  Created by delma on 07/02/2020.
+//  Copyright © 2020 delma. All rights reserved.
+//
+
+import XCTest
+@testable import CardGameApp
+
+class CardGameAppTests: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        super.setUp()
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        
+       
+        
+        
+    }
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+    func testCardShuffle() {
+        let cardDeck = CardDeck()
+        let output = """
+            > 카드 섞기
+            전체 \(cardDeck.count())장의 카드를 섞었습니다.
+            """
+        print(output)
+    }
+    func testInitCard() {
+         let cardDeck = CardDeck()
+        print("> 카드 초기화\n카드 전체를 초기화했습니다.\n총 \(cardDeck.count())장의 카드를 섞었습니다.")
+    }
+    
+    func testPickOneCard() {
+        var cardDeck = CardDeck()
+        let output = """
+        > 카드 하나 뽑기
+        \(cardDeck.removeOn())
+        총 \(cardDeck.count())장의 카드가 남아있습니다.
+        """
+        print(output)
+    }
+    
+}

--- a/CardGameApp/CardGameAppTests/Info.plist
+++ b/CardGameApp/CardGameAppTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
- card deck에서 모든 card 종류를 만들어야 하는데, enum의 모든 케이스를 어떻게 돌릴까 생각하다, `CaseIterable` 프로토콜을 이용하여 enum의 모든 케이스를 순회할 수 있게 하였습니다.
- card deck에서 card 생성 시 별도의 메소드를 사용하려다가, 굳이 메소드로 빼지 않고  card deck 생성시 모든 card가 만들어지도록 init()안에서 구현하였습니다.
- 단위 테스트를 처음 사용해봐서 일단 각각의 케이스를 문제의 예시와 동일하게 출력되게 테스트했는데, XCAsset 류의 메소드를 이용하면 보다 정확하고 빠르게 판단할 수 있을 것 같아 추후에는 XCAsset에 대해 더 알아볼 예정입니다.