### PR TITLE
[Poker game app step3] 카드덱 

### DIFF
--- a/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
+++ b/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		6A1CD24D23F15FEE00B42A97 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD24A23F15FEE00B42A97 /* Card.swift */; };
 		6A1CD24E23F15FF100B42A97 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19E023EEBC4C0070F4E3 /* ViewController.swift */; };
 		6A1CD24F23F15FF200B42A97 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19E023EEBC4C0070F4E3 /* ViewController.swift */; };
+		6A1CD25123F29B9200B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
+		6A1CD25223F29B9200B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
 		6A7B19DD23EEBC4C0070F4E3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19DC23EEBC4C0070F4E3 /* AppDelegate.swift */; };
 		6A7B19DF23EEBC4C0070F4E3 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19DE23EEBC4C0070F4E3 /* SceneDelegate.swift */; };
 		6A7B19E123EEBC4C0070F4E3 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19E023EEBC4C0070F4E3 /* ViewController.swift */; };
@@ -41,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		6A1CD24A23F15FEE00B42A97 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		6A1CD25023F29B9200B42A97 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 		6A7B19D923EEBC4C0070F4E3 /* CardGameApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CardGameApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A7B19DC23EEBC4C0070F4E3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		6A7B19DE23EEBC4C0070F4E3 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +116,7 @@
 				6A7B19E723EEBC4F0070F4E3 /* LaunchScreen.storyboard */,
 				6A7B19EA23EEBC4F0070F4E3 /* Info.plist */,
 				6A1CD24A23F15FEE00B42A97 /* Card.swift */,
+				6A1CD25023F29B9200B42A97 /* CardDeck.swift */,
 			);
 			path = CardGameApp;
 			sourceTree = "<group>";
@@ -267,6 +271,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A7B19E123EEBC4C0070F4E3 /* ViewController.swift in Sources */,
+				6A1CD25123F29B9200B42A97 /* CardDeck.swift in Sources */,
 				6A7B19DD23EEBC4C0070F4E3 /* AppDelegate.swift in Sources */,
 				6A7B19DF23EEBC4C0070F4E3 /* SceneDelegate.swift in Sources */,
 				6A1CD24B23F15FEE00B42A97 /* Card.swift in Sources */,
@@ -279,6 +284,7 @@
 			files = (
 				6A1CD24E23F15FF100B42A97 /* ViewController.swift in Sources */,
 				6A7B19F423EEBC4F0070F4E3 /* CardGameAppTests.swift in Sources */,
+				6A1CD25223F29B9200B42A97 /* CardDeck.swift in Sources */,
 				6A1CD24C23F15FEE00B42A97 /* Card.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
+++ b/CardGameApp/CardGameApp.xcodeproj/project.pbxproj
@@ -12,8 +12,9 @@
 		6A1CD24D23F15FEE00B42A97 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD24A23F15FEE00B42A97 /* Card.swift */; };
 		6A1CD24E23F15FF100B42A97 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19E023EEBC4C0070F4E3 /* ViewController.swift */; };
 		6A1CD24F23F15FF200B42A97 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19E023EEBC4C0070F4E3 /* ViewController.swift */; };
-		6A1CD25123F29B9200B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
-		6A1CD25223F29B9200B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
+		6A1CD25523F2F9AB00B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
+		6A1CD25623F2F9AC00B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
+		6A1CD25723F2F9AD00B42A97 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1CD25023F29B9200B42A97 /* CardDeck.swift */; };
 		6A7B19DD23EEBC4C0070F4E3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19DC23EEBC4C0070F4E3 /* AppDelegate.swift */; };
 		6A7B19DF23EEBC4C0070F4E3 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19DE23EEBC4C0070F4E3 /* SceneDelegate.swift */; };
 		6A7B19E123EEBC4C0070F4E3 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7B19E023EEBC4C0070F4E3 /* ViewController.swift */; };
@@ -271,7 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A7B19E123EEBC4C0070F4E3 /* ViewController.swift in Sources */,
-				6A1CD25123F29B9200B42A97 /* CardDeck.swift in Sources */,
+				6A1CD25523F2F9AB00B42A97 /* CardDeck.swift in Sources */,
 				6A7B19DD23EEBC4C0070F4E3 /* AppDelegate.swift in Sources */,
 				6A7B19DF23EEBC4C0070F4E3 /* SceneDelegate.swift in Sources */,
 				6A1CD24B23F15FEE00B42A97 /* Card.swift in Sources */,
@@ -284,7 +285,7 @@
 			files = (
 				6A1CD24E23F15FF100B42A97 /* ViewController.swift in Sources */,
 				6A7B19F423EEBC4F0070F4E3 /* CardGameAppTests.swift in Sources */,
-				6A1CD25223F29B9200B42A97 /* CardDeck.swift in Sources */,
+				6A1CD25623F2F9AC00B42A97 /* CardDeck.swift in Sources */,
 				6A1CD24C23F15FEE00B42A97 /* Card.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -295,6 +296,7 @@
 			files = (
 				6A1CD24F23F15FF200B42A97 /* ViewController.swift in Sources */,
 				6A7B19FF23EEBC4F0070F4E3 /* CardGameAppUITests.swift in Sources */,
+				6A1CD25723F2F9AD00B42A97 /* CardDeck.swift in Sources */,
 				6A1CD24D23F15FEE00B42A97 /* Card.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CardGameApp/CardGameApp.xcodeproj/xcshareddata/xcschemes/CardGameApp.xcscheme
+++ b/CardGameApp/CardGameApp.xcodeproj/xcshareddata/xcschemes/CardGameApp.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6A7B19D823EEBC4C0070F4E3"
+               BuildableName = "CardGameApp.app"
+               BlueprintName = "CardGameApp"
+               ReferencedContainer = "container:CardGameApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6A7B19EE23EEBC4F0070F4E3"
+               BuildableName = "CardGameAppTests.xctest"
+               BlueprintName = "CardGameAppTests"
+               ReferencedContainer = "container:CardGameApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6A7B19F923EEBC4F0070F4E3"
+               BuildableName = "CardGameAppUITests.xctest"
+               BlueprintName = "CardGameAppUITests"
+               ReferencedContainer = "container:CardGameApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6A7B19D823EEBC4C0070F4E3"
+            BuildableName = "CardGameApp.app"
+            BlueprintName = "CardGameApp"
+            ReferencedContainer = "container:CardGameApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6A7B19D823EEBC4C0070F4E3"
+            BuildableName = "CardGameApp.app"
+            BlueprintName = "CardGameApp"
+            ReferencedContainer = "container:CardGameApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -28,11 +28,11 @@ class Card: CustomStringConvertible {
     //
     //3. 프로퍼티를 호출할 때 클래스에서는 프로퍼티를 호출할 때 마다 "Suit().hearts" 이런 식으로 명시해줘야 하지만 enum은 추론 가능할 때 ".eight"과 같이 표현할 수 있어서 더 편하다고 생각했습니다.
 
-    enum Suit: Character {  // 한글자이기 때문에 캐릭터라고 했는데 String도 됨.
+    enum Suit: Character, CaseIterable {  // 한글자이기 때문에 캐릭터라고 했는데 String도 됨.
         case spades = "♠️", hearts = "♥️", diamonds = "♦️", clubs = "♣️"
     }
         
-    enum Rank: UInt {
+    enum Rank: UInt, CaseIterable {
         case A = 1, two, three, four, five, six, seven, eight, nine, ten, J, Q, K
     }
     

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -10,15 +10,15 @@ import Foundation
 
 class Card: CustomStringConvertible {
     
-    private var suit : Suit.RawValue
-    private var rank : Rank.RawValue
+    private var suit : Suit
+    private var rank : Rank
     var description: String {
-        return "\(suit)\(rank)"
+        return "\(suit.rawValue)\(rank.rawValue)"
     }
     
     init(suit: Suit, rank: Rank) {
-        self.suit = suit.rawValue
-        self.rank = rank.rawValue
+        self.suit = suit
+        self.rank = rank
     }
     
     //enum을 선택한 이유:
@@ -27,13 +27,19 @@ class Card: CustomStringConvertible {
     //2. 사실 지금 메모리를 고려하는게 맞는지 모르겠지만 클래스 같은 경우에는 인스턴스 생성 후 인스턴스를 해지하지 않으면 메모리에 계속 남아있지만 enum은 사용을 다하면 자동으로 스택에서 사라지기 때문에 enum이 더 낫다고 생각했습니다.
     //
     //3. 프로퍼티를 호출할 때 클래스에서는 프로퍼티를 호출할 때 마다 "Suit().hearts" 이런 식으로 명시해줘야 하지만 enum은 추론 가능할 때 ".eight"과 같이 표현할 수 있어서 더 편하다고 생각했습니다.
-
-    enum Suit: Character, CaseIterable {  // 한글자이기 때문에 캐릭터라고 했는데 String도 됨.
-        case spades = "♠️", hearts = "♥️", diamonds = "♦️", clubs = "♣️"
+    
+    enum Suit: Character, CaseIterable, CustomStringConvertible {
+        case spades = "♠️" , hearts = "♥️", diamonds = "♦️", clubs = "♣️"
+        var description: String {
+            return "\(self.rawValue)"
+        }
     }
-        
-    enum Rank: UInt, CaseIterable {
+    
+    enum Rank: UInt, CaseIterable, CustomStringConvertible {
         case A = 1, two, three, four, five, six, seven, eight, nine, ten, J, Q, K
+        var description: String {
+            return "\(self.rawValue)"
+        }
     }
     
     func descripteCard() -> String {
@@ -43,6 +49,6 @@ class Card: CustomStringConvertible {
 }
 extension Card :Equatable{
     static func == (lhs: Card, rhs: Card) -> Bool {
-        return lhs.description == rhs.description
+        return lhs.suit == rhs.suit && lhs.suit == rhs.suit
     }
 }

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -41,3 +41,4 @@ class Card: CustomStringConvertible {
     }
     
 }
+

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -43,6 +43,6 @@ class Card: CustomStringConvertible {
 }
 extension Card :Equatable{
     static func == (lhs: Card, rhs: Card) -> Bool {
-        lhs == rhs
+        return lhs.description == rhs.description
     }
 }

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -41,4 +41,8 @@ class Card: CustomStringConvertible {
     }
     
 }
-
+extension Card :Equatable{
+    static func == (lhs: Card, rhs: Card) -> Bool {
+        lhs == rhs
+    }
+}

--- a/CardGameApp/CardGameApp/Card.swift
+++ b/CardGameApp/CardGameApp/Card.swift
@@ -10,8 +10,8 @@ import Foundation
 
 class Card: CustomStringConvertible {
     
-    let suit : Suit.RawValue
-    let rank : Rank.RawValue
+    private var suit : Suit.RawValue
+    private var rank : Rank.RawValue
     var description: String {
         return "\(suit)\(rank)"
     }

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -28,8 +28,8 @@ struct CardDeck {
         return cards
     }
     
-    func shuffle() {
-        
+    func shuffle() -> [Card] {
+        return cards.shuffled()
     }
     
     func removeOne(of: Int) -> Card {

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -9,18 +9,32 @@
 import Foundation
 
 struct CardDeck {
-    var cards: [Card]
+    var cards : [Card] = []
     
-    func reset() {
+    init() {
+//        cards = self.reset()
+    }
+    
+    mutating func reset() -> [Card]{
+        var suitsOfCard = Card.Suit.allCases
+        var ranksOfCard = Card.Rank.allCases
         
+        ranksOfCard.forEach{ rank in
+            for suit in suitsOfCard {
+                let newCard = Card(suit: suit, rank: rank)
+                cards.append(newCard)
+            }
+        }
+        return cards
     }
     
     func shuffle() {
         
     }
     
-    func removeOne() -> Card {
+    func removeOne(of: Int) -> Card {
         
+        return cards[0]
     }
     
     func count() {
@@ -31,6 +45,5 @@ extension CardDeck :Equatable{
     static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
         return lhs.cards.count == rhs.cards.count
         return lhs.cards == rhs.cards
-        
     }
 }

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -1,0 +1,30 @@
+//
+//  CardDeck.swift
+//  CardGameApp
+//
+//  Created by Keunna Lee on 2020/02/11.
+//  Copyright © 2020 Keunna Lee. All rights reserved.
+//
+
+import Foundation
+
+struct CardDeck {
+    var cards: [Card]
+    
+    func reset() {
+        
+    }
+    
+    func shuffle() {
+        
+    }
+    
+    func removeOne() -> Card {
+        
+    }
+    
+    func count() {
+        
+    }
+}
+

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -32,9 +32,10 @@ struct CardDeck {
         return cards.shuffled()
     }
     
-    func removeOne(of: Int) -> Card {
-        
-        return cards[0]
+    mutating func removeOne(of index: Int) -> Card {
+        let cardToRemove = self.cards[index]
+        self.cards.remove(at: index)
+        return cardToRemove
     }
     
     func count() {

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct CardDeck {
-    var cards : [Card] = []
+    private var cards : [Card] = []
     
     init() {
         cards = self.reset()

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -16,11 +16,11 @@ struct CardDeck {
     }
     
     mutating func reset() -> [Card]{
-        var suitsOfCard = Card.Suit.allCases
-        var ranksOfCard = Card.Rank.allCases
+        let suitsOfCard = Card.Suit.allCases
+        let ranksOfCard = Card.Rank.allCases
         
         ranksOfCard.forEach{ rank in
-            for suit in suitsOfCard {
+            suitsOfCard.forEach{ suit in
                 let newCard = Card(suit: suit, rank: rank)
                 cards.append(newCard)
             }
@@ -28,8 +28,8 @@ struct CardDeck {
         return cards
     }
     
-    func shuffle() -> [Card] {
-        return self.cards.shuffled()
+    mutating func shuffle() {
+        self.cards.shuffle()
     }
     
     mutating func removeOne(of index: Int) -> Card {
@@ -41,10 +41,14 @@ struct CardDeck {
     func count() -> Int {
         return self.cards.count
     }
+    
+    func pickCard(of index: Int) -> Card {
+        return self.cards[index]
+    }
+    
 }
 extension CardDeck :Equatable{
     static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
-        return lhs.cards.count == rhs.cards.count
         return lhs.cards == rhs.cards
     }
 }

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -12,7 +12,7 @@ struct CardDeck {
     var cards : [Card] = []
     
     init() {
-//        cards = self.reset()
+        cards = self.reset()
     }
     
     mutating func reset() -> [Card]{
@@ -29,7 +29,7 @@ struct CardDeck {
     }
     
     func shuffle() -> [Card] {
-        return cards.shuffled()
+        return self.cards.shuffled()
     }
     
     mutating func removeOne(of index: Int) -> Card {
@@ -38,8 +38,8 @@ struct CardDeck {
         return cardToRemove
     }
     
-    func count() {
-        
+    func count() -> Int {
+        return self.cards.count
     }
 }
 extension CardDeck :Equatable{

--- a/CardGameApp/CardGameApp/CardDeck.swift
+++ b/CardGameApp/CardGameApp/CardDeck.swift
@@ -27,4 +27,10 @@ struct CardDeck {
         
     }
 }
-
+extension CardDeck :Equatable{
+    static func == (lhs: CardDeck, rhs: CardDeck) -> Bool {
+        return lhs.cards.count == rhs.cards.count
+        return lhs.cards == rhs.cards
+        
+    }
+}

--- a/CardGameApp/CardGameApp/ViewController.swift
+++ b/CardGameApp/CardGameApp/ViewController.swift
@@ -53,25 +53,6 @@ class ViewController: UIViewController {
         setStackView ()
         CardDeck()
         
-        print("명령어를 입력해주세요 :)")
-        let command = readLine() ?? ""
-        
-        switch command {
-        case InputView.command.reset.rawValue :
-            var cardDeck = CardDeck()
-            cardDeck.reset()
-        case InputView.command.shuffle.rawValue :
-            var cardDeck = CardDeck()
-            cardDeck.shuffle()
-        case InputView.command.count.rawValue :
-            var cardDeck = CardDeck()
-            cardDeck.count()
-        case InputView.command.removeOne.rawValue :
-            var cardDeck = CardDeck()
-            cardDeck.removeOne(of: )
-        default:
-            <#code#>
-        }
-        
+        print(Card(suit: .clubs, rank: .eight))
     }
 }

--- a/CardGameApp/CardGameApp/ViewController.swift
+++ b/CardGameApp/CardGameApp/ViewController.swift
@@ -51,5 +51,8 @@ class ViewController: UIViewController {
         addCards()
         self.view.addSubview(cardsStack)
         setStackView ()
+        CardDeck()
+        }
     }
-}
+    
+//}

--- a/CardGameApp/CardGameApp/ViewController.swift
+++ b/CardGameApp/CardGameApp/ViewController.swift
@@ -52,7 +52,26 @@ class ViewController: UIViewController {
         self.view.addSubview(cardsStack)
         setStackView ()
         CardDeck()
+        
+        print("명령어를 입력해주세요 :)")
+        let command = readLine() ?? ""
+        
+        switch command {
+        case InputView.command.reset.rawValue :
+            var cardDeck = CardDeck()
+            cardDeck.reset()
+        case InputView.command.shuffle.rawValue :
+            var cardDeck = CardDeck()
+            cardDeck.shuffle()
+        case InputView.command.count.rawValue :
+            var cardDeck = CardDeck()
+            cardDeck.count()
+        case InputView.command.removeOne.rawValue :
+            var cardDeck = CardDeck()
+            cardDeck.removeOne(of: )
+        default:
+            <#code#>
         }
+        
     }
-    
-//}
+}

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -10,11 +10,11 @@ import XCTest
 @testable import CardGameApp
 
 class CardGameAppTests: XCTestCase {
-
+    
     override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        
     }
-
+    
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
@@ -38,5 +38,64 @@ class CardGameAppTests: XCTestCase {
         // Then
         XCTAssertEqual(description, "♥️8")
     }
-
+    
+    func testReset() {
+        // Given
+        let cardDeck = CardDeck()
+        // When
+        cardDeck.reset()
+        let count = cardDeck.cards.count
+        // Then
+        XCTAssertEqual(count, 52)
+    }
+    
+    func testShuffle() { //
+        // Given
+        let cardDeck = CardDeck().cards
+        // When
+        let shuffledCardDeck = cardDeck.shuffle()
+        // Then
+        XCTAssertNotEqual(cardDeck, shuffledCardDeck)
+    }
+    
+    //    XCTAssertEqual -> 가능하게 하려면??
+    func testRemoveOne() {
+        // Given
+        let cardDeck = CardDeck().cards
+        let originalCount = cardDeck.cards.count
+        var randomCardIndexWillRemove = Int.random(in: 0 ..< originalCount)
+        let nextCardFromRemoved = cardDeck[randomCardIndexWillRemove+1]
+        // When
+        let removedOne = cardDeck.removeOne(of: randomCardIndexWillRemove)
+        let movedCardToForward = cardDeck.cards[randomCardIndexWillRemove]
+        let changedCount = cardDeck.cards.count
+        // Then
+        XCTAssertNotEqual(originalCount != changedCount)
+        // 삭제 요청된 카드 다음에 있던 카드가 삭제 후 삭제된 카드 인덱스에 있어야 한다
+        XCTAssertEqual(nextCardFromRemoved == movedCardToForward)
+        XCTAssertNotEqual(removedOne != movedCardToForward)
+    }
+    
+    func testCount() {
+        // Given
+        let cardDeck = CardDeck()
+        // When 처음값을 삭제했을 때
+        cardDeck.removeOne()
+        var count = cardDeck.count()
+        // Then
+        XCTAssertEqual(count == 51)
+        
+        // When 중간값을 삭제했을 때
+        cardDeck.removeOne()
+        count = cardDeck.count()
+        // Then
+        XCTAssertEqual(count == 50)
+        
+        // When 초기화 했을 때
+        cardDeck.reset()
+        count = cardDeck.count()
+        // Then
+        XCTAssertEqual(count == 52)
+    }
+    
 }

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -10,9 +10,11 @@ import XCTest
 @testable import CardGameApp
 
 class CardGameAppTests: XCTestCase {
+    // Given
+    var cardDeck = CardDeck()
+    var cards = CardDeck().cards
     
     override func setUp() {
-        
     }
     
     override func tearDown() {
@@ -40,8 +42,6 @@ class CardGameAppTests: XCTestCase {
     }
     
     func testReset() {
-        // Given
-        let cardDeck = CardDeck()
         // When
         cardDeck.reset()
         let count = cardDeck.cards.count
@@ -50,52 +50,47 @@ class CardGameAppTests: XCTestCase {
     }
     
     func testShuffle() { //
-        // Given
-        let cardDeck = CardDeck().cards
         // When
-        let shuffledCardDeck = cardDeck.shuffle()
+        cardDeck.shuffle()
+        let shuffledCardDeck = cardDeck.cards
         // Then
-        XCTAssertNotEqual(cardDeck, shuffledCardDeck)
+        XCTAssertNotEqual(cards, shuffledCardDeck)
     }
     
-    //    XCTAssertEqual -> 가능하게 하려면??
     func testRemoveOne() {
         // Given
-        let cardDeck = CardDeck().cards
-        let originalCount = cardDeck.cards.count
+        let originalCount = cards.count
         var randomCardIndexWillRemove = Int.random(in: 0 ..< originalCount)
-        let nextCardFromRemoved = cardDeck[randomCardIndexWillRemove+1]
+        let nextCardFromRemoved = cards[randomCardIndexWillRemove+1]
         // When
         let removedOne = cardDeck.removeOne(of: randomCardIndexWillRemove)
-        let movedCardToForward = cardDeck.cards[randomCardIndexWillRemove]
-        let changedCount = cardDeck.cards.count
+        let movedCardToForward = cards[randomCardIndexWillRemove]
+        let changedCount = cards.count
         // Then
-        XCTAssertNotEqual(originalCount != changedCount)
-        // 삭제 요청된 카드 다음에 있던 카드가 삭제 후 삭제된 카드 인덱스에 있어야 한다
-        XCTAssertEqual(nextCardFromRemoved == movedCardToForward)
-        XCTAssertNotEqual(removedOne != movedCardToForward)
+        XCTAssertNotEqual(originalCount, changedCount)
+        // 삭제 요청된 카드 다음 인덱스에 있던 카드가 삭제 후 삭제된 카드 인덱스에 있는지 확인한다
+        XCTAssertEqual(nextCardFromRemoved, movedCardToForward)
+        XCTAssertNotEqual(removedOne, movedCardToForward)
     }
     
     func testCount() {
-        // Given
-        let cardDeck = CardDeck()
         // When 처음값을 삭제했을 때
-        cardDeck.removeOne()
-        var count = cardDeck.count()
+        cardDeck.removeOne(of: 0)
+        var count = cardDeck.cards.count
         // Then
-        XCTAssertEqual(count == 51)
+        XCTAssertEqual(count, 51)
         
         // When 중간값을 삭제했을 때
-        cardDeck.removeOne()
-        count = cardDeck.count()
+        cardDeck.removeOne(of: 27)
+        count = cardDeck.cards.count
         // Then
-        XCTAssertEqual(count == 50)
+        XCTAssertEqual(count, 50)
         
         // When 초기화 했을 때
         cardDeck.reset()
-        count = cardDeck.count()
+        count = cardDeck.cards.count
         // Then
-        XCTAssertEqual(count == 52)
+        XCTAssertEqual(count, 52)
     }
     
 }

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -25,9 +25,11 @@ class CardGameAppTests: XCTestCase {
         // Given
         let viewController = ViewController()
         let cardStack = viewController.cardsStack
+        
         // When
         let description = viewController.addCards()
         let subViewCount = cardStack.subviews.count
+        
         // Then
         XCTAssertEqual(subViewCount, 7)
     }
@@ -35,8 +37,10 @@ class CardGameAppTests: XCTestCase {
     func testDescripteCard() {
         // Given
         let card = Card(suit: .hearts , rank: .eight )
+        
         // When
         let description = card.descripteCard()
+        
         // Then
         XCTAssertEqual(description, "♥️8")
     }
@@ -45,6 +49,7 @@ class CardGameAppTests: XCTestCase {
         // given
         let initCardDeckbyReset = CardDeck()
         let cardsCount = initCardDeckbyReset.count()
+        
         // Then
         XCTAssertEqual(cardsCount, 52)
     }
@@ -54,11 +59,12 @@ class CardGameAppTests: XCTestCase {
         let cardGameCardDeck = CardDeck()
         let randomIndex = Int.random(in: 0 ... 52)
         let originalCard = cardGameCardDeck.cards[randomIndex]
+        
         // When
         let shuffledCard = cardGameCardDeck.shuffle()[randomIndex]
+        
         // Then
         XCTAssertNotEqual(originalCard, shuffledCard)
-        //        XCTAssertNotEqual(originalCards.dropLast(), shuffledCards.dropLast())
     }
     
     func testRemoveOne() {
@@ -67,10 +73,12 @@ class CardGameAppTests: XCTestCase {
         let originalCount = cardDeck.cards.count
         var randomCardIndexWillRemove = Int.random(in: 1..<originalCount-1)
         let nextCardFromRemoved = cardDeck.cards[randomCardIndexWillRemove+1]
+        
         // When
         let removedOne = cardDeck.removeOne(of: randomCardIndexWillRemove)
         let movedCardToForward = cardDeck.cards[randomCardIndexWillRemove]
         let changedCount = cardDeck.cards.count
+        
         // Then
         XCTAssertNotEqual(originalCount, changedCount)
         // 삭제 요청된 카드 다음 인덱스에 있던 카드가 삭제 후 삭제된 카드 인덱스에 있는지 확인한다
@@ -103,5 +111,4 @@ class CardGameAppTests: XCTestCase {
         // Then
         XCTAssertNotEqual(removeOneMore, reset)
     }
-    
 }

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -9,29 +9,14 @@
 import XCTest
 @testable import CardGameApp
 
-class CardGameAppTests: XCTestCase {
-    // Given
-    var cardDeck = CardDeck()
-    var cards = CardDeck().cards
+class CardGameAppTests: XCTestCase  {
     
     override func setUp() {
+        
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
-    func testAddCard() {
-        // Given
-        let viewController = ViewController()
-        let cardStack = viewController.cardsStack
-        
-        // When
-        let description = viewController.addCards()
-        let subViewCount = cardStack.subviews.count
-        
-        // Then
-        XCTAssertEqual(subViewCount, 7)
     }
     
     func testDescripteCard() {
@@ -47,68 +32,86 @@ class CardGameAppTests: XCTestCase {
     
     func testReset() {
         // given
-        let initCardDeckbyReset = CardDeck()
-        let cardsCount = initCardDeckbyReset.count()
+        // CardDeck을 초기화할 때 reset() 함수가 호출됩니다.
+        var cardDeck = CardDeck()
+        let cardsCount = cardDeck.count()
         
         // Then
         XCTAssertEqual(cardsCount, 52)
     }
     
-    func testShuffle() {
+    func testCardsShuffled() {
         // Given
-        let cardGameCardDeck = CardDeck()
-        let randomIndex = Int.random(in: 0 ... 52)
-        let originalCard = cardGameCardDeck.cards[randomIndex]
+        var cardGameCardDeck = CardDeck()
+        var seed = SystemRandomNumberGenerator()
+        var randomNumber = ((0 ..< 52).shuffled(using: &seed).first)!
+        let cardBeforeRandom = cardGameCardDeck.pickCard(of: randomNumber)
         
         // When
-        let shuffledCard = cardGameCardDeck.shuffle()[randomIndex]
+        cardGameCardDeck.shuffle()
+        let cardAfterRandom = cardGameCardDeck.pickCard(of: randomNumber)
         
         // Then
-        XCTAssertNotEqual(originalCard, shuffledCard)
+        XCTAssertNotEqual(cardBeforeRandom, cardAfterRandom)
     }
     
-    func testRemoveOne() {
+    func testCountAfterRemoveOne() {
         // Given
         var cardDeck = CardDeck()
-        let originalCount = cardDeck.cards.count
-        var randomCardIndexWillRemove = Int.random(in: 1..<originalCount-1)
-        let nextCardFromRemoved = cardDeck.cards[randomCardIndexWillRemove+1]
+        let originalCount = cardDeck.count()
+        var seed = SystemRandomNumberGenerator()
+        var randomNumber = ((0 ..< 52).shuffled(using: &seed).first)!
         
         // When
-        let removedOne = cardDeck.removeOne(of: randomCardIndexWillRemove)
-        let movedCardToForward = cardDeck.cards[randomCardIndexWillRemove]
-        let changedCount = cardDeck.cards.count
+        cardDeck.removeOne(of: randomNumber)
+        let changedCount = cardDeck.count()
         
         // Then
         XCTAssertNotEqual(originalCount, changedCount)
+    }
+    
+    func testCardInSameSquenceAfterRemoveOne(){
+        //Given
+        var seed = SystemRandomNumberGenerator()
+        var IndexWillRemoveValue = ((0 ..< 52).shuffled(using: &seed).first)!
+        var cardDeck = CardDeck()
+        let cardBeforeRemoveOne = cardDeck.pickCard(of: IndexWillRemoveValue)
+        
+        //When
+        cardDeck.removeOne(of: IndexWillRemoveValue)
+        let cardAfterRemoveOne = cardDeck.pickCard(of: IndexWillRemoveValue)
+        
+        //Then
+        XCTAssertNotEqual(cardBeforeRemoveOne, cardAfterRemoveOne)
+    }
+    
+    func testSquenceIsPulled() {
+        // Given
+        var cardDeck = CardDeck()
+        let originalCount = cardDeck.count()
+        var randomCardIndexWillRemove = Int.random(in: 1..<originalCount-1)
+        let nextCardFromRemoved = cardDeck.pickCard(of: randomCardIndexWillRemove+1)
+        
+        // When
+        let removedOne = cardDeck.removeOne(of: randomCardIndexWillRemove)
+        let movedCardToForward = cardDeck.pickCard(of: randomCardIndexWillRemove)
+        
+        // Then
         // 삭제 요청된 카드 다음 인덱스에 있던 카드가 삭제 후 삭제된 카드 인덱스에 있는지 확인한다
         XCTAssertEqual(nextCardFromRemoved, movedCardToForward)
-        XCTAssertNotEqual(removedOne, movedCardToForward)
     }
     
     func testCount() {
         // Given
         var cardDeck = CardDeck()
-        let original = cardDeck.cards
-        
-        // When 처음값을 삭제했을 때
-        cardDeck.removeOne(of: 0)
-        let removeOne = cardDeck.cards
-        
-        // Then
-        XCTAssertNotEqual(original, removeOne)
-        
-        // When 중간값을 삭제했을 때
-        cardDeck.removeOne(of: 27)
-        let removeOneMore = cardDeck.cards
-        
-        // Then
-        XCTAssertNotEqual(removeOne, removeOneMore)
+        let originalCount = cardDeck.count()
+        var randomNumber = Int.random(in: 1..<originalCount-1)
         
         // When 초기화 했을 때
-        cardDeck.reset()
-        let reset = cardDeck.cards
+        cardDeck.removeOne(of: randomNumber)
+        let changedCount = cardDeck.count()
+        
         // Then
-        XCTAssertNotEqual(removeOneMore, reset)
+        XCTAssertEqual(originalCount, changedCount+1)
     }
 }

--- a/CardGameApp/CardGameAppTests/CardGameAppTests.swift
+++ b/CardGameApp/CardGameAppTests/CardGameAppTests.swift
@@ -42,30 +42,35 @@ class CardGameAppTests: XCTestCase {
     }
     
     func testReset() {
-        // When
-        cardDeck.reset()
-        let count = cardDeck.cards.count
+        // given
+        let initCardDeckbyReset = CardDeck()
+        let cardsCount = initCardDeckbyReset.count()
         // Then
-        XCTAssertEqual(count, 52)
+        XCTAssertEqual(cardsCount, 52)
     }
     
-    func testShuffle() { //
+    func testShuffle() {
+        // Given
+        let cardGameCardDeck = CardDeck()
+        let randomIndex = Int.random(in: 0 ... 52)
+        let originalCard = cardGameCardDeck.cards[randomIndex]
         // When
-        cardDeck.shuffle()
-        let shuffledCardDeck = cardDeck.cards
+        let shuffledCard = cardGameCardDeck.shuffle()[randomIndex]
         // Then
-        XCTAssertNotEqual(cards, shuffledCardDeck)
+        XCTAssertNotEqual(originalCard, shuffledCard)
+        //        XCTAssertNotEqual(originalCards.dropLast(), shuffledCards.dropLast())
     }
     
     func testRemoveOne() {
         // Given
-        let originalCount = cards.count
-        var randomCardIndexWillRemove = Int.random(in: 0 ..< originalCount)
-        let nextCardFromRemoved = cards[randomCardIndexWillRemove+1]
+        var cardDeck = CardDeck()
+        let originalCount = cardDeck.cards.count
+        var randomCardIndexWillRemove = Int.random(in: 1..<originalCount-1)
+        let nextCardFromRemoved = cardDeck.cards[randomCardIndexWillRemove+1]
         // When
         let removedOne = cardDeck.removeOne(of: randomCardIndexWillRemove)
-        let movedCardToForward = cards[randomCardIndexWillRemove]
-        let changedCount = cards.count
+        let movedCardToForward = cardDeck.cards[randomCardIndexWillRemove]
+        let changedCount = cardDeck.cards.count
         // Then
         XCTAssertNotEqual(originalCount, changedCount)
         // 삭제 요청된 카드 다음 인덱스에 있던 카드가 삭제 후 삭제된 카드 인덱스에 있는지 확인한다
@@ -74,23 +79,29 @@ class CardGameAppTests: XCTestCase {
     }
     
     func testCount() {
+        // Given
+        var cardDeck = CardDeck()
+        let original = cardDeck.cards
+        
         // When 처음값을 삭제했을 때
         cardDeck.removeOne(of: 0)
-        var count = cardDeck.cards.count
+        let removeOne = cardDeck.cards
+        
         // Then
-        XCTAssertEqual(count, 51)
+        XCTAssertNotEqual(original, removeOne)
         
         // When 중간값을 삭제했을 때
         cardDeck.removeOne(of: 27)
-        count = cardDeck.cards.count
+        let removeOneMore = cardDeck.cards
+        
         // Then
-        XCTAssertEqual(count, 50)
+        XCTAssertNotEqual(removeOne, removeOneMore)
         
         // When 초기화 했을 때
         cardDeck.reset()
-        count = cardDeck.cards.count
+        let reset = cardDeck.cards
         // Then
-        XCTAssertEqual(count, 52)
+        XCTAssertNotEqual(removeOneMore, reset)
     }
     
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ## 목차
 
 - [pokergameapp-step1](#pokergameapp-step1): StackView를 통해 동일한 비율의 7개 카드(뒷면)가 동일한 간격으로 수평으로 나열 
-- [pockerGameApp-step2](#pockerGameApp-step2): 카드 클래스 생성
+- [pockerGameApp-step2](#pockerGameApp-step2): Card 클래스 구현
+- [pockerGameApp-step3](#pockerGameApp-step3): CardDeck 클래스 구현
 
 
 ### pokergameapp-step1
@@ -105,3 +106,19 @@
 3. ViewController 클래스에서 StackView를 초기화하는 코드를 메소드로 따로 분리해서 구현했습니다.
 
 4. ViewController 클래스의 addCard메소드 실행시 StackView의 subView가 7개가 생성되는지 확인하는 테스트 코드를 추가했습니다. -> (ViewController 테스트 코드는 Unit Test 보다 UITest를 하는 편이라는 걸 알게됐습니다.)
+
+### pockerGameApp-step3
+
+20.02.11 18:00
+
+1. 테스트 코드 작성
+1-1. CardDeck 구조체의 reset 메소드를 테스트하는 코드
+1-2. CardDeck 구조체의 shuffle 메소드를 테스트하는 코드
+1-3. CardDeck 구조체의 removeOne 메소드를 테스트하는 코드
+1-4. CardDeck 구조체의 count 메소드를 테스트하는 코드
+
+RGR(red, green, refactor) & BDD(given, when, then) 시도
+2. 테스트 코드가 에러가 나는 상태(Red)에서 Red를 없애면서 구현
+2-1. 테스트 코드에서 XCTAssertEqual 메소드나 XCTAssertNotEqual 메소드를 사용하기 위해 CardDeck 구조체와 Card 클래스에 extension으로 Equatable 프로토콜을 채택 
+2-1. Suit enum과 Rank enum이 CaseIterable 프로토콜 채택
+2-2. CaseIterable 프로토콜의 메소드인 allCases를 활용해 CardDeck 구조체에서 reset 메소드 구현

--- a/README.md
+++ b/README.md
@@ -78,3 +78,30 @@
 
    ![image-20200210212217610](/Users/keunnalee/Library/Application Support/typora-user-images/image-20200210212217610.png)
 
+20.02.11 피드백 반영 후 수정한 사항
+
+1. Card 클래스가 CustomStringConvertible프로토콜을 채택한 후 프로퍼티 추가.
+
+   ```swift
+    class Card: CustomStringConvertible {
+       
+       let suit : Suit.RawValue
+       let rank : Rank.RawValue
+       var description: String {
+           return "\(suit)\(rank)"
+       }
+       
+       init(suit: Suit, rank: Rank) {
+           self.suit = suit.rawValue
+           self.rank = rank.rawValue
+       }
+    }
+   ```
+
+   
+
+2. ViewController 클래스에서 makeCard 메소드와 setCard 메소드를 합쳤습니다.
+
+3. ViewController 클래스에서 StackView를 초기화하는 코드를 메소드로 따로 분리해서 구현했습니다.
+
+4. ViewController 클래스의 addCard메소드 실행시 StackView의 subView가 7개가 생성되는지 확인하는 테스트 코드를 추가했습니다. -> (ViewController 테스트 코드는 Unit Test 보다 UITest를 하는 편이라는 걸 알게됐습니다.)

--- a/README.md
+++ b/README.md
@@ -122,3 +122,96 @@ RGR(red, green, refactor) & BDD(given, when, then) 시도
 2-1. 테스트 코드에서 XCTAssertEqual 메소드나 XCTAssertNotEqual 메소드를 사용하기 위해 CardDeck 구조체와 Card 클래스에 extension으로 Equatable 프로토콜을 채택 
 2-1. Suit enum과 Rank enum이 CaseIterable 프로토콜 채택
 2-2. CaseIterable 프로토콜의 메소드인 allCases를 활용해 CardDeck 구조체에서 reset 메소드 구현
+
+20.02.12 16: 15
+
+3. 처음처럼 모든 카드를 다시 채워넣는 reset메소드 구현. 
+
+4. 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제하는  removeOne 메소드 구현
+
+3 & 4. CardDeck 구조체가 가지고있는 프로퍼티 cards를 변경하는 메소드(reset, removeOne) 구현하다가 self(CardDeck 구조체)가 immutable하기 때문에 reset, removeOne 메소드 이름 앞에 mutating 키워드를 추가해 변경 가능하도록 바꿨습니다.
+
+5. 전체 카드를 랜덤하게 섞는 Shuffle 메소드 구현
+
+셔플 알고리즘에 대해서 공부했습니다.
+
+5-1. Fisher–Yates shuffle algorithm (original)
+
+```swift
+var items = ["A", "B", "C", "D", "E", "F", "G", "H"]
+var shuffled = [String]();
+
+for i in 0..<items.count
+{
+    let rand = Int(arc4random_uniform(UInt32(items.count)))
+
+    shuffled.append(items[rand])
+
+    items.remove(at: rand)
+}
+
+print(shuffled)
+```
+5-2. Knuth Shuffle: Fisher–Yates shuffle algorithm (modern)
+https://developer.apple.com/videos/play/wwdc2018/406/?time=1289
+(Fisher–Yates shuffle: 23:05 ~ )
+애플의 shuffle 메소드는 이 방식으로 구현됐습니다.
+
+```swift
+var items = ["A", "B", "C", "D", "E", "F", "G", "H"]
+var last = items.count - 1
+
+while(last > 0)
+{
+    let rand = Int(arc4random_uniform(UInt32(last)))
+
+    print("swap items[\(last)] = \(items[last]) with items[\(rand)] = \(items[rand])")
+
+    items.swapAt(last, rand)
+
+    print(items)
+
+    last -= 1
+}
+```
+original과 달리 두 개의 Collection이 필요없습니다.
+5-3. navie shuffle algorithm vs Fisher–Yates shuffle
+https://dyladan.me/abc/2016/01/20/shuffle/
+https://gist.github.com/robertmryan/b002b7d524646fd677bb3979c89ec331 
+
+```swift
+extension Array {
+    
+    /// Simple implementation of Fisher-Yates
+    
+    mutating func shuffle() {
+        for i in 0 ..< count - 1 {
+            let j = i + Int(arc4random_uniform(UInt32(count - i)))
+            swapAt(i, j)
+        }
+    }
+    
+    /// Naive implementation that introduces biases
+    
+    mutating func shuffleBiased() {
+        for i in 0 ..< count {
+            let j = Int(arc4random_uniform(UInt32(count)))
+            swapAt(i, j)
+        }
+    }
+}
+```
+navie shuffle은 편향된 셔플 결과를 보이는 반면 Fisher-Yates shuffle은 항상 비슷한 셔플 결과를 보입니다.
+
+- shuffle()과 shuffled() 공통점과 차이점
+  * 공통점 : Collection의 value들을 섞습니다., 복잡도가 O(n)입니다.
+  * 차이점: shuffled 메소드는 셔플한 Collection을 반환합니다.
+
+6. 갖고 있는 카드 개수를 반환하는 Count 메소드 구현
+
+- count 갖고 있는 카드 개수를 반환합니다.
+- shuffle 기능은 전체 카드를 랜덤하게 섞습니다.
+- removeOne 기능은 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제합니다.
+- reset 처음처럼 모든 카드를 다시 채워넣습니다.
+
+7. 테스트 코드에서 Card 객체 비교시 Thread가 끊임없이 돌아갔습니다 -> Card 클래스의 Equatable 비교 대상을 수정했습니다.


### PR DESCRIPTION
* 과정

1. 먼저 `테스트 코드` 작성 후 코드 구현하는 방법을 시도해봤습니다.
   CardDeck 구조체의 reset 메소드, shuffle 메소드, removeOne 메소드, count 메소드를 테스트하는 코드

2. 테스트 코드가 에러가 나는 상태(Red)에서 Red를 없애면서 구현했습니다.
   2-1. 테스트 코드에서 XCTAssertEqual 메소드나 XCTAssertNotEqual 메소드를 사용하기 위해 CardDeck 구조체와 Card 클래스에 extension으로 `Equatable 프로토콜`을 채택 
   2-1. Suit enum과 Rank enum이 `CaseIterable 프로토콜` 채택 ->
   2-2. CaseIterable 프로토콜의 메소드인 allCases를 활용해 CardDeck 구조체에서 reset 메소드 구현

20.02.12 16: 15
3. 메소드 구현
3-1.처음처럼 모든 카드를 다시 채워넣는 reset 메소드 구현했습니다. 
3-2. 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제하는  removeOne 메소드 구현했습니다.

3-1 & 3-2. CardDeck 구조체가 가지고있는 프로퍼티 cards를 변경하는 메소드(reset, removeOne) 구현하다가 self(CardDeck 구조체)가 immutable하기 때문에 reset, removeOne 메소드 이름 앞에 mutating 키워드를 추가해 변경 가능하도록 바꿨습니다.

4.셔플 알고리즘에 대해서 공부 후  전체 카드를 랜덤하게 섞는 Shuffle 메소드 구현했습니다.
4-1. Fisher–Yates shuffle algorithm (original) 와 Knuth Shuffle: Fisher–Yates shuffle algorithm (modern)original, navie shuffle algorithm 에 대해서 봤습니다.
-> Knuth Shuffle는 복잡도가 O(n) Fisher–Yates shuffle algorithm (original)보다 복잡도가 낮습니다.
navie shuffle은 Fisher-Yates shuffle와 달리 편향된 결과를 보입니다.

4-2. shuffle()과 shuffled() 공통점과 차이점
  * 공통점 : Collection의 value들을 섞습니다, 복잡도가 O(n)입니다.
  * 차이점: shuffled 메소드는 셔플한 Collection을 반환합니다.

5. 갖고 있는 카드 개수를 반환하는 Count 메소드 구현
- count 갖고 있는 카드 개수를 반환합니다.
- shuffle 기능은 전체 카드를 랜덤하게 섞습니다.
- removeOne 기능은 카드 인스턴스 중에 하나를 반환하고 목록에서 삭제합니다.
- reset 처음처럼 모든 카드를 다시 채워넣습니다.

6.  테스트 코드에서 Card 객체 비교시 Thread가 끊임없이 돌아갔습니다 -> Card 클래스의 Equatable 비교 대상을 수정했습니다.

배운 점 : 셔플 알고리즘, Structure의 mutating.

고민한 점 : 테스트 코드를 짤 때 어떤 테스트를 통과해야 해당 메소드를 신뢰할 수 있는 걸일까. 특히 셔플 메소드 테스트 코드를 짰을 때, 배열 자체를 비교할지 아니면 특정 인덱스의 value를 비교할지 고민했습니다.

궁금한 점 : 객체지향 설계 방식에 맞도록 내부 속성을 모두 감추고 다음 인터페이스만 보이도록 구현하는 방법을 모르겠습니다.

P.s. 사용자 입력 시나리오에 맞는 출력화면은 추후 리팩토링과 함께 구현하겠습니다 ㅠㅠ