### PR TITLE
[Lollo] Step 3 - 카드덱 구현과 테스트

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		E438090725DA3D6D0024C294 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E438090625DA3D6D0024C294 /* Assets.xcassets */; };
 		E438090A25DA3D6D0024C294 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E438090825DA3D6D0024C294 /* LaunchScreen.storyboard */; };
 		E438091525DA63D60024C294 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438091425DA63D60024C294 /* Card.swift */; };
+		E4CE9B4C25DB5DF4000CE7F4 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CE9B4B25DB5DF4000CE7F4 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		E438090925DA3D6D0024C294 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E438090B25DA3D6D0024C294 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E438091425DA63D60024C294 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
+		E4CE9B4B25DB5DF4000CE7F4 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +64,7 @@
 				E43808FF25DA3D6C0024C294 /* SceneDelegate.swift */,
 				E438090125DA3D6C0024C294 /* ViewController.swift */,
 				E438091425DA63D60024C294 /* Card.swift */,
+				E4CE9B4B25DB5DF4000CE7F4 /* CardDeck.swift */,
 				E438090325DA3D6C0024C294 /* Main.storyboard */,
 				E438090625DA3D6D0024C294 /* Assets.xcassets */,
 				E438090825DA3D6D0024C294 /* LaunchScreen.storyboard */,
@@ -141,6 +144,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E438090225DA3D6C0024C294 /* ViewController.swift in Sources */,
+				E4CE9B4C25DB5DF4000CE7F4 /* CardDeck.swift in Sources */,
 				E43808FE25DA3D6C0024C294 /* AppDelegate.swift in Sources */,
 				E438090025DA3D6C0024C294 /* SceneDelegate.swift in Sources */,
 				E438091525DA63D60024C294 /* Card.swift in Sources */,

--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		E438090A25DA3D6D0024C294 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E438090825DA3D6D0024C294 /* LaunchScreen.storyboard */; };
 		E438091525DA63D60024C294 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438091425DA63D60024C294 /* Card.swift */; };
 		E4CE9B4C25DB5DF4000CE7F4 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CE9B4B25DB5DF4000CE7F4 /* CardDeck.swift */; };
+		E4CE9B5025DB73BA000CE7F4 /* PrintFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4CE9B4F25DB73BA000CE7F4 /* PrintFactory.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		E438090B25DA3D6D0024C294 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E438091425DA63D60024C294 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		E4CE9B4B25DB5DF4000CE7F4 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
+		E4CE9B4F25DB73BA000CE7F4 /* PrintFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +67,7 @@
 				E438090125DA3D6C0024C294 /* ViewController.swift */,
 				E438091425DA63D60024C294 /* Card.swift */,
 				E4CE9B4B25DB5DF4000CE7F4 /* CardDeck.swift */,
+				E4CE9B4F25DB73BA000CE7F4 /* PrintFactory.swift */,
 				E438090325DA3D6C0024C294 /* Main.storyboard */,
 				E438090625DA3D6D0024C294 /* Assets.xcassets */,
 				E438090825DA3D6D0024C294 /* LaunchScreen.storyboard */,
@@ -145,6 +148,7 @@
 			files = (
 				E438090225DA3D6C0024C294 /* ViewController.swift in Sources */,
 				E4CE9B4C25DB5DF4000CE7F4 /* CardDeck.swift in Sources */,
+				E4CE9B5025DB73BA000CE7F4 /* PrintFactory.swift in Sources */,
 				E43808FE25DA3D6C0024C294 /* AppDelegate.swift in Sources */,
 				E438090025DA3D6C0024C294 /* SceneDelegate.swift in Sources */,
 				E438091525DA63D60024C294 /* Card.swift in Sources */,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -14,10 +14,10 @@ class Card {
     let suit: Suit
     
     enum Suit: String, CaseIterable {
-        case spade = "\u{2660}"
-        case club = "\u{2663}"
-        case heart = "\u{2665}"
-        case diamond = "\u{2666}"
+        case spade = "\u{2660}\u{FE0F}"
+        case club = "\u{2663}\u{FE0F}"
+        case heart = "\u{2665}\u{FE0F}"
+        case diamond = "\u{2666}\u{FE0F}"
     }
     
     /// 1~13까지만 설정 가능하도록 enum 통해 초기화하되,

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -13,7 +13,7 @@ class Card {
     /// init 시 가독성을 위해 영문으로 case 이름 생성, 출력을 위한 유니코드를 rawValue로 설정
     let suit: Suit
     
-    enum Suit: String {
+    enum Suit: String, CaseIterable {
         case spade = "\u{2660}"
         case club = "\u{2663}"
         case heart = "\u{2665}"
@@ -24,7 +24,7 @@ class Card {
     /// 내부 rank는 계산 편의성 위해 Int로 저장, 프린트용 변환은 개별 메소드로 구현
     let rank: Int
     
-    enum Rank: Int {
+    enum Rank: Int, CaseIterable {
         case rank1 = 1,
              rank2, rank3, rank4, rank5, rank6, rank7,
              rank8, rank9, rank10, rank11, rank12, rank13

--- a/PokerGameApp/PokerGameApp/Card.swift
+++ b/PokerGameApp/PokerGameApp/Card.swift
@@ -20,24 +20,30 @@ class Card {
         case diamond = "\u{2666}"
     }
     
-    /// 추후 크기 비교가 용이하도록 내부 rank는 Int 타입으로 설정하고,
-    /// 출력 시에는 개별 메소드를 통해 A, J, Q, K 등 특수 경우 문자 변환
-    let rankNum: Int
+    /// 1~13까지만 설정 가능하도록 enum 통해 초기화하되,
+    /// 내부 rank는 계산 편의성 위해 Int로 저장, 프린트용 변환은 개별 메소드로 구현
+    let rank: Int
     
-    init(suit: Suit, rank: Int) {
+    enum Rank: Int {
+        case rank1 = 1,
+             rank2, rank3, rank4, rank5, rank6, rank7,
+             rank8, rank9, rank10, rank11, rank12, rank13
+    }
+    
+    init(suit: Suit, rank: Rank) {
         self.suit = suit
-        self.rankNum = rank
+        self.rank = rank.rawValue
     }
 }
 
 //MARK: - 출력 관련
-extension Card {
-    func printCard() {
-        print(suit.rawValue + printableRank(from: rankNum))
+extension Card: CustomStringConvertible {
+    var description: String {
+        return "\(suit.rawValue)\(printableRank(from: rank))"
     }
     
-    private func printableRank(from n: Int) -> String {
-        switch n {
+    private func printableRank(from rank: Int) -> String {
+        switch rank {
         case 1:
             return "A"
         case 11:
@@ -47,7 +53,7 @@ extension Card {
         case 13:
             return "K"
         default:
-            return String(n)
+            return String(rank)
         }
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,60 @@
+//
+//  CardDeck.swift
+//  PokerGameApp
+//
+//  Created by Song on 2021/02/16.
+//
+
+import Foundation
+
+struct CardDeck {
+    
+    var currentDeck = [Card]()
+    
+    private var wholeDeck: [Card] {
+        var deck = [Card]()
+        
+        for suit in Card.Suit.allCases {
+            deck.append(contentsOf: deckPart(from: suit))
+        }
+    
+        return deck
+    }
+    
+    init() { reset() }
+    
+    func count() -> Int { return currentDeck.count }
+    
+    mutating func shuffle() {
+        //modern fisher-yates shuffle
+        let lastIndex = currentDeck.count - 1
+        
+        for i in 0...lastIndex {
+            let currentIndex = lastIndex - i
+            let randomIndex = Int.random(in: 0...currentIndex)
+            let temp = currentDeck[randomIndex]
+            currentDeck[randomIndex] = currentDeck[currentIndex]
+            currentDeck[currentIndex] = temp
+        }
+    }
+    
+    mutating func removeOne() -> Card? {
+        return currentDeck.popLast()
+    }
+    
+    mutating func reset() {
+        currentDeck = wholeDeck
+        shuffle()
+    }
+    
+    private func deckPart(from suit: Card.Suit) -> [Card] {
+        var cards = [Card]()
+        
+        for rank in Card.Rank.allCases {
+            let card = Card(suit: suit, rank: rank)
+            cards.append(card)
+        }
+        
+        return cards
+    }
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct CardDeck {
     
-    var currentDeck = [Card]()
+    private var currentDeck = [Card]()
     
     private var wholeDeck: [Card] {
         var deck = [Card]()
@@ -21,30 +21,27 @@ struct CardDeck {
         return deck
     }
     
-    init() { reset() }
+    init() { currentDeck = wholeDeck }
     
     func count() -> Int { return currentDeck.count }
     
-    mutating func shuffle() {
-        //modern fisher-yates shuffle
-        let lastIndex = currentDeck.count - 1
+    mutating func shuffle() -> Int {
+        let lastIdx = count() - 1
         
-        for i in 0...lastIndex {
-            let currentIndex = lastIndex - i
-            let randomIndex = Int.random(in: 0...currentIndex)
-            let temp = currentDeck[randomIndex]
-            currentDeck[randomIndex] = currentDeck[currentIndex]
-            currentDeck[currentIndex] = temp
+        for i in 0...lastIdx {
+            let currIdx = lastIdx - i
+            let randIdx = Int.random(in: 0...currIdx)
+            (currentDeck[randIdx], currentDeck[currIdx]) = (currentDeck[currIdx], currentDeck[randIdx])
         }
+        
+        return count()
     }
     
-    mutating func removeOne() -> Card? {
-        return currentDeck.popLast()
-    }
+    mutating func removeOne() -> Card? { return currentDeck.popLast() }
     
-    mutating func reset() {
+    mutating func reset() -> Int {
         currentDeck = wholeDeck
-        shuffle()
+        return count()
     }
     
     private func deckPart(from suit: Card.Suit) -> [Card] {

--- a/PokerGameApp/PokerGameApp/PrintFactory.swift
+++ b/PokerGameApp/PokerGameApp/PrintFactory.swift
@@ -1,0 +1,30 @@
+//
+//  PrintFactory.swift
+//  PokerGameApp
+//
+//  Created by Song on 2021/02/16.
+//
+
+import Foundation
+
+struct PrintFactory {
+    
+    let shuffleMessage = "덱의 카드를 섞었습니다"
+    let resetMessage = "덱을 리셋했습니다"
+    
+    func deckCount(_ count: Int) -> String {
+        return "현재 \(count)장의 카드가 있습니다"
+    }
+    
+    func deckContents(from deck: [Card]) -> String {
+        return "현재 덱의 구성: \(deck)"
+    }
+    
+    func cardInfo(from card: Card?) -> String {
+        if let card = card {
+            return "현재 카드: \(card)"
+        } else {
+            return "덱에 카드가 없습니다"
+        }
+    }
+}

--- a/PokerGameApp/PokerGameApp/PrintFactory.swift
+++ b/PokerGameApp/PokerGameApp/PrintFactory.swift
@@ -9,22 +9,23 @@ import Foundation
 
 struct PrintFactory {
     
-    let shuffleMessage = "덱의 카드를 섞었습니다"
-    let resetMessage = "덱을 리셋했습니다"
-    
-    func deckCount(_ count: Int) -> String {
-        return "현재 \(count)장의 카드가 있습니다"
+    func deckCountInfo(from count: Int) -> String {
+        return "덱에 \(count)장의 카드가 있습니다.\n"
     }
     
-    func deckContents(from deck: [Card]) -> String {
-        return "현재 덱의 구성: \(deck)"
-    }
-    
-    func cardInfo(from card: Card?) -> String {
+    func cardDrawn(card: Card?, remainingCount: Int) -> String {
         if let card = card {
-            return "현재 카드: \(card)"
+            return "> 카드 뽑기\n현재 카드: \(card)\n\(deckCountInfo(from: remainingCount))"
         } else {
-            return "덱에 카드가 없습니다"
+            return "덱에 카드가 없습니다.\n"
         }
+    }
+    
+    func shuffleMessage(with shuffleCount: Int) -> String {
+        return "> 카드 섞기\n총 \(shuffleCount)장의 카드를 섞었습니다\n"
+    }
+    
+    func resetMessage(with deckCount: Int) -> String {
+        return "> 카드 초기화\n덱을 초기화했습니다.\n\(deckCountInfo(from: deckCount))"
     }
 }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -19,16 +19,11 @@ class ViewController: UIViewController {
         var cardDeck = CardDeck()
         let P = PrintFactory()
         
-        print(P.deckContents(from: cardDeck.currentDeck))
-        print(P.deckCount(cardDeck.count()))
-        print(P.cardInfo(from: cardDeck.removeOne()))
-        print(P.deckCount(cardDeck.count()))
-        cardDeck.shuffle()
-        print(P.shuffleMessage)
-        print(P.cardInfo(from: cardDeck.removeOne()))
-        cardDeck.reset()
-        print(P.resetMessage)
-        print(P.deckCount(cardDeck.count()))
+        print(P.resetMessage(with: cardDeck.reset()))
+        print(P.shuffleMessage(with: cardDeck.shuffle()))
+        print(P.cardDrawn(card: cardDeck.removeOne(), remainingCount: cardDeck.count()))
+        print(P.cardDrawn(card: cardDeck.removeOne(), remainingCount: cardDeck.count()))
+        print(P.cardDrawn(card: cardDeck.removeOne(), remainingCount: cardDeck.count()))
     }
     
     private func setBackground() {

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -16,33 +16,35 @@ class ViewController: UIViewController {
         setBackground()
         addCards(count: 7)
         
-        let card1 = Card(suit: .club, rank: 13)
-        let card2 = Card(suit: .heart, rank: 7)
-        card1.printCard()
-        card2.printCard()
+        let card1 = Card(suit: .club, rank: .rank13)
+        let card2 = Card(suit: .heart, rank: .rank7)
+        print(card1)
+        print(card2)
     }
     
     private func setBackground() {
         guard let tile = UIImage(named: "bg_pattern.png") else { return }
-        self.view.backgroundColor = UIColor(patternImage: tile)
+        view.backgroundColor = UIColor(patternImage: tile)
     }
     
     private func addCards(count: Int) {
         
-        let cntInCGF = CGFloat(count)
+        let countInCGF = CGFloat(count)
         
-        let fullWidth = self.view.bounds.width
-        let marginUp = self.view.bounds.height/10
-        let marginRL = fullWidth/cntInCGF/10
+        let viewSize = (width: view.bounds.width, height: view.bounds.height)
+        let marginRatio: CGFloat = 0.1, cardRatio: CGFloat = 1.27
+        
+        let marginUp = viewSize.height * marginRatio
+        let marginRL = viewSize.width / countInCGF * marginRatio
 
-        let cardWidth = (fullWidth - marginRL*(cntInCGF+1))/cntInCGF
+        let cardWidth = (viewSize.width - marginRL * (countInCGF + 1)) / countInCGF
         
         for i in 0..<count {
             let cardView = UIImageView(image: cardBackside)
-            cardView.frame = CGRect(x: cardWidth*CGFloat(i) + marginRL*(CGFloat(i)+1),
+            cardView.frame = CGRect(x: cardWidth * CGFloat(i) + marginRL * (CGFloat(i) + 1),
                                     y: marginUp,
                                     width: cardWidth,
-                                    height: cardWidth*1.27)
+                                    height: cardWidth * cardRatio)
             view.addSubview(cardView)
         }
     }

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -16,10 +16,19 @@ class ViewController: UIViewController {
         setBackground()
         addCards(count: 7)
         
-        let card1 = Card(suit: .club, rank: .rank13)
-        let card2 = Card(suit: .heart, rank: .rank7)
-        print(card1)
-        print(card2)
+        var cardDeck = CardDeck()
+        let P = PrintFactory()
+        
+        print(P.deckContents(from: cardDeck.currentDeck))
+        print(P.deckCount(cardDeck.count()))
+        print(P.cardInfo(from: cardDeck.removeOne()))
+        print(P.deckCount(cardDeck.count()))
+        cardDeck.shuffle()
+        print(P.shuffleMessage)
+        print(P.cardInfo(from: cardDeck.removeOne()))
+        cardDeck.reset()
+        print(P.resetMessage)
+        print(P.deckCount(cardDeck.count()))
     }
     
     private func setBackground() {


### PR DESCRIPTION
Step 3를 완료하여 PR 보냅니다🙂

PR 메시지가 다소 길어졌네요 하하..



### 주요 학습 내용

- **지난 스텝 리팩토링**
  - `CustomStringConvertible` 에 대해 학습하고 class 내부에서 print하지 않도록 개선하였습니다.
  - rank 초기화 시에도 enum을 활용하도록 변경하였습니다.
  - View 구성 시 쓰이는 비율 등의 숫자를 상수화하여 의미가 명확히 전달되도록 개선하였습니다.
- **struct & class**
  - struct와 class의 특성을 알아보니 좀 더 변화에 민감한 정보를 저장하거나 안정성이 필요할 때 struct를 사용하는 것이 나을 거라는 생각이 들었습니다. 
  - [애플 개발자 문서](https://developer.apple.com/documentation/swift/choosing_between_structures_and_classes)에서도 default로 struct를 쓰는 것이 좋으며, 그 경우 코드를 부분적으로 관리하기 용이하다는 설명을 확인할 수 있었습니다. 
  - 다만, 현재 프로젝트에서 등 실제 경우에서는 아직 명확하게 와닿지가 않아서 경험을 통해 차이를 체감할 필요가 있을 것 같습니다. 
- **shuffle**: O(n)의 시간복잡도를 가져 가장 효율적이라고 판단한 modern 버전의 Fisher-Yates shuffle 방식을 구현했습니다.
- **private**: 참조 접근자를 private으로 설정하면 프로젝트 내 다른 파일에서도 접근이 불가능해져서 메소드나 프로퍼티를 숨길 수 있었습니다.
- **print & return**
  - 이번 구현에서 가장 큰 고민이 됐던 파트입니다. 
  - 먼저, `PrintFactory` 구조체를 생성하여, 필요한 정보를 받고 출력할 메시지 별로 String을 반환하는 메소드를 만들었습니다.
  - 그리고 shuffle(), reset() 메소드의 경우처럼 카드 수량의 출력이 필요한 경우, `CardDeck` 구조체의 반환 값을 Int로 조정하고 count()를 반환하도록 하였습니다.
  - 추후에도 Label 등에 남은 카드의 수량을 표시해야할 가능성이 높을 것 같아서 Int를 반환해도 괜찮을 것이라고 생각했습니다.
- **class 메모리 관리 방식**: 
  - `ARC` 키워드를 알게 되어 해당 키워드를 통해 학습해보았습니다.
  -  `Card` class에 deinit 시 "카드 소멸" 을 출력하도록 했더니 removeOne()실행 시 각 1번 씩, 더 이상 카드를 활용하는 함수가 없을 때나 리셋 시엔 남은 카드의 수만큼 메시지가 출력되는 것을 확인할 수 있었습니다.
- **git**: `squash`, `reword` 등을 활용하여 앞선 commit들을 합치거나 메시지를 수정하는 방법을 익혀 보았습니다.