### PR TITLE
Poker game step 3

### DIFF
--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		CE1C23D225DA3C4500109419 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE1C23D125DA3C4500109419 /* Assets.xcassets */; };
 		CE1C23D525DA3C4500109419 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1C23D325DA3C4500109419 /* LaunchScreen.storyboard */; };
 		CE1C23E025DB645800109419 /* PokerCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1C23DF25DB645800109419 /* PokerCard.swift */; };
+		CE1C23E825DBE70300109419 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1C23E725DBE70300109419 /* CardDeck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		CE1C23D425DA3C4500109419 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		CE1C23D625DA3C4500109419 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE1C23DF25DB645800109419 /* PokerCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerCard.swift; sourceTree = "<group>"; };
+		CE1C23E725DBE70300109419 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,6 +68,7 @@
 				CE1C23D325DA3C4500109419 /* LaunchScreen.storyboard */,
 				CE1C23D625DA3C4500109419 /* Info.plist */,
 				CE1C23DF25DB645800109419 /* PokerCard.swift */,
+				CE1C23E725DBE70300109419 /* CardDeck.swift */,
 			);
 			path = PokerGameApp;
 			sourceTree = "<group>";
@@ -141,6 +144,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE1C23CD25DA3C4400109419 /* ViewController.swift in Sources */,
+				CE1C23E825DBE70300109419 /* CardDeck.swift in Sources */,
 				CE1C23E025DB645800109419 /* PokerCard.swift in Sources */,
 				CE1C23C925DA3C4400109419 /* AppDelegate.swift in Sources */,
 				CE1C23CB25DA3C4400109419 /* SceneDelegate.swift in Sources */,

--- a/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
+++ b/PokerGameApp/PokerGameApp.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		CE1C23D525DA3C4500109419 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1C23D325DA3C4500109419 /* LaunchScreen.storyboard */; };
 		CE1C23E025DB645800109419 /* PokerCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1C23DF25DB645800109419 /* PokerCard.swift */; };
 		CE1C23E825DBE70300109419 /* CardDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1C23E725DBE70300109419 /* CardDeck.swift */; };
+		CE1C23EB25DCBE2E00109419 /* Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1C23EA25DCBE2E00109419 /* Test.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		CE1C23D625DA3C4500109419 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE1C23DF25DB645800109419 /* PokerCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokerCard.swift; sourceTree = "<group>"; };
 		CE1C23E725DBE70300109419 /* CardDeck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardDeck.swift; sourceTree = "<group>"; };
+		CE1C23EA25DCBE2E00109419 /* Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Test.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +71,7 @@
 				CE1C23D625DA3C4500109419 /* Info.plist */,
 				CE1C23DF25DB645800109419 /* PokerCard.swift */,
 				CE1C23E725DBE70300109419 /* CardDeck.swift */,
+				CE1C23EA25DCBE2E00109419 /* Test.swift */,
 			);
 			path = PokerGameApp;
 			sourceTree = "<group>";
@@ -148,6 +151,7 @@
 				CE1C23E025DB645800109419 /* PokerCard.swift in Sources */,
 				CE1C23C925DA3C4400109419 /* AppDelegate.swift in Sources */,
 				CE1C23CB25DA3C4400109419 /* SceneDelegate.swift in Sources */,
+				CE1C23EB25DCBE2E00109419 /* Test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -8,5 +8,19 @@
 import Foundation
 
 struct CardDeck {
+    var Cards: [PokerCard] = []
     
+    init() {
+        self.Cards = makeCards()
+    }
+    
+    private func makeCards() -> [PokerCard] {
+        var tempCards:[PokerCard] = []
+        for suit in PokerCard.Suit.allCases {
+            for rank in PokerCard.Rank.allCases {
+                tempCards.append(PokerCard(suit: suit, rank: rank))
+            }
+        }
+        return tempCards
+    }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -37,4 +37,12 @@ struct CardDeck {
             randomRange -= 1
         }
     }
+    
+    mutating func removeOne() -> PokerCard? {
+        return self.Cards.popLast()
+    }
+    
+    mutating func reset() {
+        self.Cards = makeCards()
+    }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct CardDeck {
-    var Cards: [PokerCard] = []
+    var cards: [PokerCard] = []
     var count: Int {
-        return Cards.count
+        return cards.count
     }
     
     init() {
-        self.Cards = makeCards()
+        self.cards = makeCards()
     }
     
     private func makeCards() -> [PokerCard] {
@@ -33,16 +33,16 @@ struct CardDeck {
         
         while randomRange != 0 {
             let pickedIndex = Int.random(in: 0...randomRange)
-            self.Cards.swapAt(randomRange, pickedIndex)
+            self.cards.swapAt(randomRange, pickedIndex)
             randomRange -= 1
         }
     }
     
     mutating func removeOne() -> PokerCard? {
-        return self.Cards.popLast()
+        return self.cards.popLast()
     }
     
     mutating func reset() {
-        self.Cards = makeCards()
+        self.cards = makeCards()
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -1,0 +1,12 @@
+//
+//  CardDeck.swift
+//  PokerGameApp
+//
+//  Created by user on 2021/02/16.
+//
+
+import Foundation
+
+struct CardDeck {
+    
+}

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -17,7 +17,7 @@ struct CardDeck {
         self.reset()
     }
     
-    mutating private func reset() {
+    mutating func reset() {
         var tempCards:[PokerCard] = []
         for suit in PokerCard.Suit.allCases {
             for rank in PokerCard.Rank.allCases {

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -27,4 +27,14 @@ struct CardDeck {
         return tempCards
     }
     
+    //  Fisher-Yates shuffle(Knuth)
+    mutating func shuffle() {
+        var randomRange = self.count - 1
+        
+        while randomRange != 0 {
+            let pickedIndex = Int.random(in: 0...randomRange)
+            self.Cards.swapAt(randomRange, pickedIndex)
+            randomRange -= 1
+        }
+    }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -14,17 +14,17 @@ struct CardDeck {
     }
     
     init() {
-        self.cards = makeCards()
+        self.reset()
     }
     
-    private func makeCards() -> [PokerCard] {
+    mutating private func reset() {
         var tempCards:[PokerCard] = []
         for suit in PokerCard.Suit.allCases {
             for rank in PokerCard.Rank.allCases {
                 tempCards.append(PokerCard(suit: suit, rank: rank))
             }
         }
-        return tempCards
+        self.cards = tempCards
     }
     
     //  Fisher-Yates shuffle(Knuth)
@@ -40,9 +40,5 @@ struct CardDeck {
     
     mutating func removeOne() -> PokerCard? {
         return self.cards.popLast()
-    }
-    
-    mutating func reset() {
-        self.cards = makeCards()
     }
 }

--- a/PokerGameApp/PokerGameApp/CardDeck.swift
+++ b/PokerGameApp/PokerGameApp/CardDeck.swift
@@ -9,6 +9,9 @@ import Foundation
 
 struct CardDeck {
     var Cards: [PokerCard] = []
+    var count: Int {
+        return Cards.count
+    }
     
     init() {
         self.Cards = makeCards()
@@ -23,4 +26,5 @@ struct CardDeck {
         }
         return tempCards
     }
+    
 }

--- a/PokerGameApp/PokerGameApp/PokerCard.swift
+++ b/PokerGameApp/PokerGameApp/PokerCard.swift
@@ -11,11 +11,11 @@ class PokerCard : CustomStringConvertible {
 
     //  PokerCard 클래스 내부에 Suit, Rank를 표현하는 코드가 있으면
     //  보기에 더 직관적일것 같아서 nested enum으로 구현했습니다.
-    enum Suit: Character {
+    enum Suit: Character, CaseIterable {
         case spades = "♠", hearts = "♥", diamonds = "♦", clubs = "♣"
     }
     
-    enum Rank: Int {
+    enum Rank: Int, CaseIterable {
         case one = 1, two, three, four, five, six, seven, eight, nine, ten
         case jack, queen, king
     }
@@ -25,6 +25,8 @@ class PokerCard : CustomStringConvertible {
     var description: String {
         var over10: Character
         switch self.rank {
+        case .one:
+            over10 = "A"
         case .jack:
             over10 = "J"
         case .queen:

--- a/PokerGameApp/PokerGameApp/PokerCard.swift
+++ b/PokerGameApp/PokerGameApp/PokerCard.swift
@@ -7,33 +7,40 @@
 
 import Foundation
 
-class PokerCard {
+class PokerCard : CustomStringConvertible {
 
     //  PokerCard 클래스 내부에 Suit, Rank를 표현하는 코드가 있으면
     //  보기에 더 직관적일것 같아서 nested enum으로 구현했습니다.
-    //  게다가 rawValue를 아래처럼 Character, Int로 정해주면 출력할 때
-    //  rawValue나 이를 유니코드로 변환한 것만 출력하면 된다고 생각해 이 구조를 택했습니다.
     enum Suit: Character {
         case spades = "♠", hearts = "♥", diamonds = "♦", clubs = "♣"
     }
     
-    //  제 생각에는 카드를 구별할 때 인스턴스의 rawValue를 알아내서 구별하기 보다는
-    //  타입으로 구별을 하는 일이 많을 것 같아서 타입의 rawValue는 유니코드로 구현해서
-    //  이를 출력할 때 J,Q,K를 보여주도록 바꿨습니다.
     enum Rank: Int {
-        case one = 49, two, three, four, five, six, seven, eight, nine, ten
-        case jack = 74, queen = 81, king = 75
+        case one = 1, two, three, four, five, six, seven, eight, nine, ten
+        case jack, queen, king
     }
     
     let suit:Suit, rank:Rank
+    
+    var description: String {
+        var over10: Character
+        switch self.rank {
+        case .jack:
+            over10 = "J"
+        case .queen:
+            over10 = "Q"
+        case .king:
+            over10 = "K"
+        default:
+            return "\(self.suit.rawValue)\(self.rank.rawValue)"
+        }
+        return "\(self.suit.rawValue)\(over10)"
+    }
+    
     
     init(suit: Suit, rank: Rank) {
         self.suit = suit
         self.rank = rank
     }
     
-    //  rank.rawValue는 범위가 제한되어 있어 과감하게 !로 옵셔널을 해제했습니다.
-    func cardInfo() -> String {
-        return "\(self.suit.rawValue)\(UnicodeScalar(self.rank.rawValue)!)"
-    }
 }

--- a/PokerGameApp/PokerGameApp/PokerCard.swift
+++ b/PokerGameApp/PokerGameApp/PokerCard.swift
@@ -11,32 +11,40 @@ class PokerCard : CustomStringConvertible {
 
     //  PokerCard 클래스 내부에 Suit, Rank를 표현하는 코드가 있으면
     //  보기에 더 직관적일것 같아서 nested enum으로 구현했습니다.
-    enum Suit: Character, CaseIterable {
+    enum Suit: Character, CaseIterable, CustomStringConvertible {
         case spades = "♠", hearts = "♥", diamonds = "♦", clubs = "♣"
+        
+        var description: String {
+            return "\(self.rawValue)"
+        }
     }
     
-    enum Rank: Int, CaseIterable {
+    enum Rank: Int, CaseIterable, CustomStringConvertible {
         case one = 1, two, three, four, five, six, seven, eight, nine, ten
-        case jack, queen, king
+        case jack
+        case queen
+        case king
+        
+        var description: String {
+            switch self {
+            case .one:
+                return "A"
+            case .jack:
+                return "J"
+            case .queen:
+                return "Q"
+            case .king:
+                return "K"
+            default:
+                return "\(self.rawValue)"
+            }
+        }
     }
     
     let suit:Suit, rank:Rank
     
     var description: String {
-        var over10: Character
-        switch self.rank {
-        case .one:
-            over10 = "A"
-        case .jack:
-            over10 = "J"
-        case .queen:
-            over10 = "Q"
-        case .king:
-            over10 = "K"
-        default:
-            return "\(self.suit.rawValue)\(self.rank.rawValue)"
-        }
-        return "\(self.suit.rawValue)\(over10)"
+        return "\(self.suit)\(self.rank)"
     }
     
     

--- a/PokerGameApp/PokerGameApp/Test.swift
+++ b/PokerGameApp/PokerGameApp/Test.swift
@@ -1,0 +1,45 @@
+//
+//  Test.swift
+//  PokerGameApp
+//
+//  Created by user on 2021/02/17.
+//
+
+import Foundation
+
+struct ActionTest {
+    var cards = CardDeck()
+    
+    mutating func resetTest() {
+        cards.reset()
+        print("카드 전체를 초기화했습니다.")
+        print("총 \(cards.count)장의 카드가 있습니다.")
+    }
+    
+    mutating func shuffleTest() {
+        cards.shuffle()
+        print("전체 \(cards.count)의 카드를 섞었습니다.")
+    }
+    
+    mutating func removeOneTest() {
+        if let card = cards.removeOne() {
+            print(card)
+            print("총 \(cards.count)장의 카드가 남아있습니다.")
+        } else {
+            print("남아있는 카드가 없어 뽑을 수 없습니다.")
+        }
+    }
+    
+    mutating func startTest() {
+        self.resetTest()
+        self.shuffleTest()
+        
+        for _ in 0...51 {
+            self.removeOneTest()
+        }
+        
+        self.removeOneTest()
+        self.resetTest()
+        self.shuffleTest()
+    }
+}

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -21,13 +21,12 @@ class ViewController: UIViewController {
         
         let heartQ = PokerCard(suit: .hearts, rank: .queen)
         let club7 = PokerCard(suit: .clubs, rank: .seven)
-        print("\(heartQ.cardInfo())")
-        print("\(club7.cardInfo())")
+        print(heartQ)
+        print(club7)
     }
 
     func show7CardBack() {
         //  카드 7장을 놓을 수 있는 치수 설정
-        //  카드 사이 빈 공간을 만들기 위해 cardCount + 1로 frame.width를 나눈다.
         let cardCount:CGFloat = 7
         let cardWidth = self.view.frame.width / (cardCount + 1)
         let cardHeight = cardWidth * 1.27

--- a/PokerGameApp/PokerGameApp/ViewController.swift
+++ b/PokerGameApp/PokerGameApp/ViewController.swift
@@ -23,6 +23,9 @@ class ViewController: UIViewController {
         let club7 = PokerCard(suit: .clubs, rank: .seven)
         print(heartQ)
         print(club7)
+        
+        var actionTest = ActionTest()
+        actionTest.startTest()
     }
 
     func show7CardBack() {

--- a/README.md
+++ b/README.md
@@ -10,3 +10,23 @@
 - frame길이를 통해 카드 너비, 높이 지정
 
 완성 날짜: 2021.02.15 월요일 오후 9:59분
+
+## Step-2, 3
+
+<p align="center">
+<img width="533" alt="step2,3-1" src="https://user-images.githubusercontent.com/45817559/108171497-ed6a2680-713e-11eb-94ea-0a4cbc391cc2.png">
+</p>
+
+<p align="center">
+<img width="533" alt="step2,3-2" src="https://user-images.githubusercontent.com/45817559/108171516-f78c2500-713e-11eb-9e0b-cb4b214ac635.png">
+</p>
+
+- 카드 데이터를 추상화해서 클래스로 구현.
+- 클래스를 print할 때, CustomStringConvertible 프로토콜을 채택해 커스터마이징
+- 카드 덱 구현
+    - count: 갖고 있는 카드 개수 반환
+    - shuffle: 전체 카드를 랜덤하게 섞음
+    - removeOne: 카드 인스턴스 중 하나를 반환하고 목록에서 삭제
+    - reset: 처음처럼 모든 카드를 다시 채워넣음
+
+완성 날짜: 2021.02.17 수요일 오후 4:41분


### PR DESCRIPTION
**지난 PR문제점**
- 이전 Step에서 PR, 머지 후 피드백을 반영하기 위해 브랜치를 옮기지 않고 작업을 했습니다.
- 작업 후 제 브랜치로 돌아가 upstream과 싱크를 맞추고 피드백을 반영한 브랜치를 다시 머지했습니다.
- 그러자 피드백 이전(upstream에 머지가 이미 된)의 커밋로그까지 같이 머지되어 커밋이 중복되었습니다.
- 그래서 다음 Step 완료 후 PR을 보내는데 이전의 이미 머지된 커밋로그까지 몽땅 추가되었습니다.

**해결 방법**
- upstream의 위치에서 새로운 브랜치를 만들고, 이후의 작업들 중 중복되지 않은 커밋을 `git cherry-pick 커밋명`으로 복사했습니다. 
- 일일이 커밋명을 찾아 복사하기 보다 `git cherry-pick oldest-commit^..latest-commit`을 사용해 특정 범위의 커밋을 복사했습니다.
- 새로운 브랜치를 푸시 후 PR보냅니다.

**질문**   
- 마스터가 머지해주시고 피드백을 남겨주시는데, 이 피드백을 반영할때도 새로운 브랜치를 만들어서 작업을 하는게 좋을까요?

알게된 점
- 구조체와 클래스의 가장 큰 차이점을 꼽자고 한다면 상속과 값/참조 타입인 것 같습니다.
- shuffle 알고리즘 중 fisher-yates 알고리즘을 찾아보았습니다. 이는 예전버전(O(N^2))과 현대버전(O(N))이 있는데 Swift의 shuffle()은 현대버전을 사용합니다.
- deinit을 통해 클래스의 메모리관리를 알아보았습니다. 카드를 그냥 뽑을 경우 메모리가 해제되지만, 새로운 프로퍼티에 반환하면 이 프로퍼티가 nil이 되어야 해제가 되었습니다. reset시에는 남아있는 메모리를 모두 해제한 후 다시 할당하는 것을 확인할 수 있었습니다.